### PR TITLE
MAINT: obtain numpy-distutils from numpy main repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,5 +12,5 @@
 	url = https://github.com/MacPython/gfortran-install.git
 [submodule "numpy-distutils"]
 	path = numpy-distutils
-	url = https://github.com/pv/numpy.git
-	branch = distutils
+	url = https://github.com/numpy/numpy.git
+	branch = master


### PR DESCRIPTION
The necessary distutils changes were merged to master, so we can get
them there.