### PR TITLE
MAINT: pin versions of all build dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
         - BUILD_COMMIT=v0.19.1
         - PLAT=x86_64
         - NP_BUILD_DEP="numpy==1.8.2"
+        - CYTHON_BUILD_DEP="Cython==0.26.1"
         - NP_TEST_DEP="numpy==1.8.2"
         - UNICODE_WIDTH=32
         - MANYLINUX_URL="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
@@ -109,7 +110,7 @@ before_install:
           CONTAINER=wheels;
           UPLOAD_ARGS="--no-update-index";
       fi
-    - BUILD_DEPENDS="$NP_BUILD_DEP Cython"
+    - BUILD_DEPENDS="$NP_BUILD_DEP $CYTHON_BUILD_DEP"
     - TEST_DEPENDS="$NP_TEST_DEP nose pytest"
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ environment:
       OPENBLAS_64: https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-5f998ef_gcc7_1_0_win64.zip
       OPENBLAS_32_SHA256: 0a12804b08d475179a0411936f509b44d7512f084b4a81c2fa3abe8c9ac4ee09
       OPENBLAS_64_SHA256: 8f11d8a5a79795a3a1ccb2326c979a0ca426e623eee93f8e35239e3c21e62cd6
+      CYTHON_BUILD_DEP: Cython==0.26.1
       NUMPY_TEST_DEP: numpy==1.13.1
       TEST_MODE: fast
       APPVEYOR_SAVE_CACHE_ON_ERROR: true
@@ -147,7 +148,7 @@ install:
   - pip install "wheel==0.26"
 
   # Install build requirements.
-  - pip install "Cython>=0.25" "%NUMPY_BUILD_DEP%"
+  - pip install "%CYTHON_BUILD_DEP%" "%NUMPY_BUILD_DEP%"
 
   # Replace numpy distutils with a version that can build with msvc + mingw-gfortran.
   - ps: |


### PR DESCRIPTION
Pin build dependencies to "known good" versions.

The argument for pinning build dependencies in this repository is:

The point is to be able to build wheels in a controlled way that we
can be sure works, such that e.g. Cython bugs don't torpedo 
the release process.

Testing whether there are incompatibilities in build dependencies (e.g.
whether latest Cython version works) on the other hand should be done
in the main CI repository.

@rgommers: ping --- I think it would be best to pin the deps also in the daily branch. This way, there is a continuous testing that the process that's going to be used for the releases produces usable wheels.