### PR TITLE
Switch numpy-distutils to a version that bundles msvcp140.dll in the wheels

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,5 +12,5 @@
 	url = https://github.com/MacPython/gfortran-install.git
 [submodule "numpy-distutils"]
 	path = numpy-distutils
-	url = https://github.com/numpy/numpy.git
-	branch = master
+	url = https://github.com/pv/numpy.git
+	branch = distutils-msvcp


### PR DESCRIPTION
Bundle msvcp*.dll in the wheel to address https://github.com/scipy/scipy/issues/7969

numpy.distutils patch from https://github.com/numpy/numpy/pull/9819