### PR TITLE
Switch numpy-distutils to a version that bundles msvcp140.dll in the …

### DIFF
--- a/LICENSE_win32.txt
+++ b/LICENSE_win32.txt
@@ -121,6 +121,32 @@ License: GPLv3 + runtime exception
   see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
   <http://www.gnu.org/licenses/>.
 
+
+Name: Microsoft Visual C++ Runtime Files
+Files: extra-dll\msvcp*.dll
+License: MSVC
+  https://www.visualstudio.com/license-terms/distributable-code-microsoft-visual-studio-2015-rc-microsoft-visual-studio-2015-sdk-rc-includes-utilities-buildserver-files/#visual-c-runtime
+
+  Subject to the License Terms for the software, you may copy and
+  distribute with your program any of the files within the followng
+  folder and its subfolders except as noted below. You may not modify
+  these files.
+
+    C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist
+
+  You may not distribute the contents of the following folders:
+
+    C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\debug_nonredist
+    C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\onecore\debug_nonredist
+
+  Subject to the License Terms for the software, you may copy and
+  distribute the following files with your program in your program’s
+  application local folder or by deploying them into the Global
+  Assembly Cache (GAC):
+
+  VC\atlmfc\lib\mfcmifc80.dll
+  VC\atlmfc\lib\amd64\mfcmifc80.dll
+
 ----
 
 Full text of license texts referred to above follows (that they are

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -163,6 +163,30 @@ build_script:
   - git checkout %BUILD_COMMIT%
   # Append license text relevant for the built wheel
   - type ..\LICENSE_win32.txt >> LICENSE.txt
+  # Copy over additional DLLs to bundle to the wheels
+  #
+  # The find commands below are mainly to find the paths where the libraries are.
+  - C:\cygwin\bin\find "C:\Program Files (x86)\Microsoft Visual Studio 14.0" -type f -name 'msvcp*.dll'
+  - C:\cygwin\bin\find "C:\Program Files (x86)\Microsoft Visual Studio 10.0" -type f -name 'msvcp*.dll'
+  - C:\cygwin\bin\find "C:\Program Files (x86)\Microsoft Visual Studio 9.0" -type f -name 'msvcp*.dll'
+  # * Python 3.6
+  - mkdir build\lib.win32-3.6\scipy\extra-dll
+  - mkdir build\lib.win-amd64-3.6\scipy\extra-dll
+  - copy "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x86\Microsoft.VC140.CRT\msvcp140.dll" "build\lib.win32-3.6\scipy\extra-dll\"
+  - copy "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x64\Microsoft.VC140.CRT\msvcp140.dll" "build\lib.win-amd64-3.6\scipy\extra-dll\"
+  # * Python 3.5
+  - mkdir build\lib.win32-3.5\scipy\extra-dll
+  - mkdir build\lib.win-amd64-3.5\scipy\extra-dll
+  - copy "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x86\Microsoft.VC140.CRT\msvcp140.dll" "build\lib.win32-3.5\scipy\extra-dll\"
+  - copy "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x64\Microsoft.VC140.CRT\msvcp140.dll" "build\lib.win-amd64-3.5\scipy\extra-dll\"
+  # * Python 3.4
+  #   Didn't find the redist libs on appveyor for MSVC 10.0; hopefully few people use this old Python.
+  # * Python 2.7
+  - mkdir build\lib.win32-2.7\scipy\extra-dll
+  - mkdir build\lib.win-amd64-2.7\scipy\extra-dll
+  - copy "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\redist\x86\Microsoft.VC90.CRT\msvcp90.dll" "build\lib.win32-2.7\scipy\extra-dll\"
+  - copy "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\redist\amd64\Microsoft.VC90.CRT\msvcp90.dll" "build\lib.win-amd64-2.7\scipy\extra-dll\"
+  # Build wheel using setup.py
   - ps: |
       $PYTHON_ARCH = $env:PYTHON_ARCH
       If ($PYTHON_ARCH -eq 32) {


### PR DESCRIPTION
Bundle msvcp*.dll in the wheels to address https://github.com/scipy/scipy/issues/7969

The bundling is done manually just by copying the dlls to a place from which they'll be included in the wheel.

I didn't find redistributable msvcp100.dll for python 3.4 in the compiler distributions on appveyor, so those wheels aren't going to get the dll. Hopefully, few people use this Python version and we can just ignore this issue.

TODO:

- [x] Update LICENSE_win32.txt
- [ ] Check it actually works (!)