### PR TITLE
Bundle all msvc*90 files because the license requires it

### DIFF
--- a/LICENSE_win32.txt
+++ b/LICENSE_win32.txt
@@ -123,7 +123,7 @@ License: GPLv3 + runtime exception
 
 
 Name: Microsoft Visual C++ Runtime Files
-Files: extra-dll\msvcp*.dll
+Files: extra-dll\msvcp140.dll
 License: MSVC
   https://www.visualstudio.com/license-terms/distributable-code-microsoft-visual-studio-2015-rc-microsoft-visual-studio-2015-sdk-rc-includes-utilities-buildserver-files/#visual-c-runtime
 
@@ -146,6 +146,38 @@ License: MSVC
 
   VC\atlmfc\lib\mfcmifc80.dll
   VC\atlmfc\lib\amd64\mfcmifc80.dll
+
+
+Name: Microsoft Visual C++ Runtime Files
+Files: extra-dll\msvc*90.dll, extra-dll\Microsoft.VC90.CRT.manifest
+License: MSVC
+  For your convenience, we have provided the following folders for
+  use when redistributing VC++ runtime files. Subject to the license
+  terms for the software, you may redistribute the folder
+  (unmodified) in the application local folder as a sub-folder with
+  no change to the folder name. You may also redistribute all the
+  files (*.dll and *.manifest) within a folder, listed below the
+  folder for your convenience, as an entire set.
+
+  \VC\redist\x86\Microsoft.VC90.ATL\
+   atl90.dll
+   Microsoft.VC90.ATL.manifest
+  \VC\redist\ia64\Microsoft.VC90.ATL\
+   atl90.dll
+   Microsoft.VC90.ATL.manifest
+  \VC\redist\amd64\Microsoft.VC90.ATL\
+   atl90.dll
+   Microsoft.VC90.ATL.manifest
+  \VC\redist\x86\Microsoft.VC90.CRT\
+   msvcm90.dll
+   msvcp90.dll
+   msvcr90.dll
+   Microsoft.VC90.CRT.manifest
+  \VC\redist\ia64\Microsoft.VC90.CRT\
+   msvcm90.dll
+   msvcp90.dll
+   msvcr90.dll
+   Microsoft.VC90.CRT.manifest
 
 ----
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -184,8 +184,8 @@ build_script:
   # * Python 2.7
   - mkdir build\lib.win32-2.7\scipy\extra-dll
   - mkdir build\lib.win-amd64-2.7\scipy\extra-dll
-  - copy "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\redist\x86\Microsoft.VC90.CRT\msvcp90.dll" "build\lib.win32-2.7\scipy\extra-dll\"
-  - copy "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\redist\amd64\Microsoft.VC90.CRT\msvcp90.dll" "build\lib.win-amd64-2.7\scipy\extra-dll\"
+  - copy "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\redist\x86\Microsoft.VC90.CRT"\*.* "build\lib.win32-2.7\scipy\extra-dll\"
+  - copy "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\redist\amd64\Microsoft.VC90.CRT"\*.* "build\lib.win-amd64-2.7\scipy\extra-dll\"
   # Build wheel using setup.py
   - ps: |
       $PYTHON_ARCH = $env:PYTHON_ARCH


### PR DESCRIPTION
There's some weird crap in the MSVC 2008 license that requires distributing all of the runtime DLLs at once.