### PR TITLE
Do not fail tests on emitted warnings + use runtests for test running on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,7 @@ before_install:
           UPLOAD_ARGS="--no-update-index";
       fi
     - BUILD_DEPENDS="$NP_BUILD_DEP $CYTHON_BUILD_DEP"
-    - TEST_DEPENDS="$NP_TEST_DEP nose pytest"
+    - TEST_DEPENDS="$NP_TEST_DEP pytest pytest-xdist pytest-faulthandler pytest-env"
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh
     - before_install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -212,8 +212,11 @@ before_test:
   - python -m pip install "%NUMPY_TEST_DEP%"
 
 test_script:
+  - cd ..
+  - mkdir tmp_test
+  - cd tmp_test
   - python ..\check_license.py
-  - python runtests.py -n -m %TEST_MODE% -- -n6 --junitxml=%cd%\junit-results.xml -rfEX
+  - python ..\run_scipy_tests.py %TEST_MODE% -- -n6 --junitxml=%cd%\junit-results.xml -rfEX
 
 after_test:
   # Upload test results to Appveyor

--- a/config.sh
+++ b/config.sh
@@ -57,12 +57,14 @@ function run_tests {
     # Runs tests on installed distribution from an empty directory
     # OSX tests seem to time out pretty often
     if [ -z "$IS_OSX" ]; then
-        local extra="full"
+        local testmode="full"
+    else
+        local testmode="fast"
     fi
     # Check bundled license file
     python ../check_license.py
     # Run tests
-    python ../run_scipy_tests.py $extra
+    python ../run_scipy_tests.py $testmode -- -n2 -rfEX
     # Show BLAS / LAPACK used
     python -c 'import scipy; scipy.show_config()'
 }

--- a/run_scipy_tests.py
+++ b/run_scipy_tests.py
@@ -1,13 +1,30 @@
-""" Run scipy tests allowing for pytest and nosetests
+"""
+run_scipy_tests.py TEST_MODE [-- PYTEST_ARGS..]
+
+Run scipy tests allowing for pytest and nosetests
 """
 
 import sys
+import argparse
 
-import scipy
 
-ret = scipy.test(*sys.argv[1:], verbose=3)
-if hasattr(ret, 'wasSuccessful'):
-    # Nosetests version
-    ret = ret.wasSuccessful()
+def main():
+    p = argparse.ArgumentParser(usage=__doc__.strip())
+    p.add_argument('test_mode', metavar='TEST_MODE')
+    p.add_argument('pytest_args', metavar='PYTEST_ARGS', nargs='*')
+    args = p.parse_args()
 
-sys.exit(not ret)
+    import scipy
+    print("Scipy: {} {}".format(scipy.__version__, scipy.__path__))
+    ret = scipy.test(args.test_mode, extra_argv=args.pytest_args)
+
+    if hasattr(ret, 'wasSuccessful'):
+        # Nosetests version
+        ret = ret.wasSuccessful()
+
+    sys.exit(not ret)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
We don't want to fail wheel builds because of e.g. emitted deprecationwarnings, so make pytest treat warnings only as warnings (which is the default when running scipy.test outside of the development tree).

This probably needs to merged also to master, since we probably don't want to e.g. using matplotlib deprecated behavior at this release stage.