### PR TITLE
Set LDFLAGS for stripping at link time

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -10,11 +10,13 @@ OPENBLAS_VERSION=0.2.18
 source gfortran-install/gfortran_utils.sh
 
 function build_wheel {
-  export FFLAGS="$FFLAGS -fPIC -Wl,-strip-all"
     if [ -z "$IS_OSX" ]; then
+        unset FFLAGS
+        export LDFLAGS="-shared -Wl,-strip-all"
         build_libs $PLAT
         build_pip_wheel $@
     else
+        export FFLAGS="$FFLAGS -fPIC"
         build_osx_wheel $@
     fi
 }


### PR DESCRIPTION
Numpy distutils appears to only look at the LDFLAGS environment variable
when determining how to link fortran.

Note that distutils and numpy.distutils interpret the LDFLAGS variable
in slightly different ways, with the latter requiring that -shared is
included there. <s>To work around this, we concatenate the Python and numpy
defaults.</s>

[Appveyor build cancelled manually, since this does not touch appveyor config.]

Fixes: #30