### PR TITLE
Unpin 'wheel' package version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -158,11 +158,8 @@ install:
       cp $lib $destination
       ls $destination
 
-  # Upgrade to the latest pip and setuptools.
-  - python -m pip install -U pip setuptools
-
-  # Pin wheel to 0.26 to avoid Windows ABI tag for built wheel
-  - pip install "wheel==0.26"
+  # Upgrade to the latest pip, setuptools, and wheel.
+  - python -m pip install -U pip setuptools wheel
 
   # Install build requirements.
   - pip install "%CYTHON_BUILD_DEP%" "%NUMPY_BUILD_DEP%"


### PR DESCRIPTION
We had 'wheel==0.26' pinned to avoid problems with old pip versions that
had issues with platform tags.  Today this is no longer any problem, so
unpin the wheel package version.