### PR TITLE
Set NUMPY_TEST_DEP according to wheel availability for Windows py3.7 builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,12 +33,14 @@ environment:
       PYTHON_VERSION: 3.7
       PYTHON_ARCH: 32
       NUMPY_BUILD_DEP: numpy==1.14.5
+      NUMPY_TEST_DEP: numpy==1.14.5
       CYTHON_BUILD_DEP: Cython
 
     - PYTHON: C:\Python37-x64
       PYTHON_VERSION: 3.7
       PYTHON_ARCH: 64
       NUMPY_BUILD_DEP: numpy==1.14.5
+      NUMPY_TEST_DEP: numpy==1.14.5
       CYTHON_BUILD_DEP: Cython
 
     - PYTHON: C:\Python36


### PR DESCRIPTION
Closes #35 