### PR TITLE
MAINT: bump Cython to 0.29.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
         - BUILD_COMMIT=master
         - PLAT=x86_64
         - NP_BUILD_DEP="numpy==1.8.2"
-        - CYTHON_BUILD_DEP="Cython==0.26.1"
+        - CYTHON_BUILD_DEP="Cython==0.29.0"
         - NP_TEST_DEP="numpy==1.8.2"
         - UNICODE_WIDTH=32
         - MANYLINUX_URL="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
       OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.0-win_amd64-gcc_7_1_0.zip"
       OPENBLAS_32_SHA256: 4d8ebb7deb23e9aa39837087a8e41ac4cc0c0e44fa60861e1568e974bdbd7be6
       OPENBLAS_64_SHA256: e1bea2d94fe1c54c3cd1da62440a7975826427bc2dd55e67d064059632ddf323
-      CYTHON_BUILD_DEP: Cython==0.26.1
+      CYTHON_BUILD_DEP: Cython==0.29.0
       NUMPY_TEST_DEP: numpy==1.13.1
       TEST_MODE: fast
       APPVEYOR_SAVE_CACHE_ON_ERROR: true


### PR DESCRIPTION
As [discussed](https://github.com/scipy/scipy/issues/9464#issuecomment-437541036) with @rgommers and @charris, bumping Cython version in preparation for  SciPy `1.2.0rc1` wheel building.

I've not messed with the Cython `language_level` directive stuff that now emits a FutureWarning -- leaving that alone seemed ok for generating the source distributions, though I don't know if that's bad practice.

Not sure if I'm going to need elevated permissions for this repo or not -- I think I'll need to create a branch for 1.2.x for wheel building soon, right? And point the wheel builds to the appropriate 1.2.x scipy repo branch rc commit.