### PR TITLE
MAINT: travis_wait for wheelhouse_uploader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,7 +150,7 @@ after_success:
     # Upload may not work for Python 3.7:
     # https://github.com/ogrisel/wheelhouse-uploader/issues/27
     - pip install wheelhouse-uploader
-    - python -m wheelhouse_uploader upload --local-folder
+    - travis_wait python -m wheelhouse_uploader upload --local-folder
           ${TRAVIS_BUILD_DIR}/wheelhouse/
           $UPLOAD_ARGS
           $CONTAINER


### PR DESCRIPTION
We're seeing pretty frequent Travis CI failures due to [timeouts from `wheelhouse_uploader`](https://api.travis-ci.org/v3/job/458866343/log.txt) not producing output for 10 minutes. 

The Travis CI docs [suggest using the `travis_wait` function](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received) in these kinds of scenarios, so I'm hoping this will help alleviate the timeouts in Travis wheel builds & that there is no more serious issue.