### PR TITLE
Remove Python 2.7 and Python 3.4 from master builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ env:
         # Also see DAILY_COMMIT below
         - BUILD_COMMIT=master
         - PLAT=x86_64
-        - NP_BUILD_DEP="numpy==1.8.2"
+        - NP_BUILD_DEP="numpy==1.13.3"
         - CYTHON_BUILD_DEP="Cython==0.29.0"
-        - NP_TEST_DEP="numpy==1.8.2"
+        - NP_TEST_DEP="numpy==1.13.3"
         - UNICODE_WIDTH=32
         - MANYLINUX_URL="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
         - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
@@ -31,52 +31,26 @@ matrix:
   include:
     - os: linux
       env:
-        - MB_PYTHON_VERSION=2.7
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - UNICODE_WIDTH=16
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - PLAT=i686
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - PLAT=i686
-        - UNICODE_WIDTH=16
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.4
-        # Python 3.4 needs more recent numpy (for testing only)
-        - NP_TEST_DEP=numpy==1.9.3
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.4
-        - PLAT=i686
-        - NP_TEST_DEP=numpy==1.9.3
-    - os: linux
-      env:
         - MB_PYTHON_VERSION=3.5
-        - NP_BUILD_DEP=numpy==1.9.3
-        - NP_TEST_DEP=numpy==1.9.3
+        - NP_BUILD_DEP=numpy==1.13.3
+        - NP_TEST_DEP=numpy==1.13.3
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.5
         - PLAT=i686
-        - NP_BUILD_DEP=numpy==1.9.3
-        - NP_TEST_DEP=numpy==1.9.3
+        - NP_BUILD_DEP=numpy==1.13.3
+        - NP_TEST_DEP=numpy==1.13.3
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
-        - NP_BUILD_DEP=numpy==1.11.3
-        - NP_TEST_DEP=numpy==1.11.3
+        - NP_BUILD_DEP=numpy==1.13.3
+        - NP_TEST_DEP=numpy==1.13.3
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
         - PLAT=i686
-        - NP_BUILD_DEP=numpy==1.11.3
-        - NP_TEST_DEP=numpy==1.11.3
+        - NP_BUILD_DEP=numpy==1.13.3
+        - NP_TEST_DEP=numpy==1.13.3
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.7
@@ -93,27 +67,15 @@ matrix:
     - os: osx
       language: generic
       env:
-        - MB_PYTHON_VERSION=2.7
-    - os: osx
-      language: generic
-      env:
-        - MB_PYTHON_VERSION=3.4
-        - NP_TEST_DEP=numpy==1.9.3
-    - os: osx
-      language: generic
-      env:
         - MB_PYTHON_VERSION=3.5
-        # OSX build of scipy on Python 3.5 needs built 1.8.2 wheel to avoid
-        # https://github.com/numpy/numpy/issues/6204.  numpy 1.8.2 wheel for
-        # Python 3.5 at nipy manylinux URL.
-        - NP_BUILD_DEP=numpy==1.8.2
-        - NP_TEST_DEP=numpy==1.9.3
+        - NP_BUILD_DEP=numpy==1.13.3
+        - NP_TEST_DEP=numpy==1.13.3
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.6
-        - NP_BUILD_DEP=numpy==1.11.3
-        - NP_TEST_DEP=numpy==1.11.3
+        - NP_BUILD_DEP=numpy==1.13.3
+        - NP_TEST_DEP=numpy==1.13.3
     - os: osx
       language: generic
       env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
       OPENBLAS_32_SHA256: 4d8ebb7deb23e9aa39837087a8e41ac4cc0c0e44fa60861e1568e974bdbd7be6
       OPENBLAS_64_SHA256: e1bea2d94fe1c54c3cd1da62440a7975826427bc2dd55e67d064059632ddf323
       CYTHON_BUILD_DEP: Cython==0.29.0
-      NUMPY_TEST_DEP: numpy==1.13.1
+      NUMPY_TEST_DEP: numpy==1.13.3
       TEST_MODE: fast
       APPVEYOR_SAVE_CACHE_ON_ERROR: true
       APPVEYOR_SKIP_FINALIZE_ON_EXIT: true
@@ -46,42 +46,22 @@ environment:
     - PYTHON: C:\Python36
       PYTHON_VERSION: 3.6
       PYTHON_ARCH: 32
-      NUMPY_BUILD_DEP: numpy==1.12.1
+      NUMPY_BUILD_DEP: numpy==1.13.3
 
     - PYTHON: C:\Python36-x64
       PYTHON_VERSION: 3.6
       PYTHON_ARCH: 64
-      NUMPY_BUILD_DEP: numpy==1.12.1
+      NUMPY_BUILD_DEP: numpy==1.13.3
 
     - PYTHON: C:\Python35
       PYTHON_VERSION: 3.5
       PYTHON_ARCH: 32
-      NUMPY_BUILD_DEP: numpy==1.10.4
+      NUMPY_BUILD_DEP: numpy==1.13.3
 
     - PYTHON: C:\Python35-x64
       PYTHON_VERSION: 3.5
       PYTHON_ARCH: 64
-      NUMPY_BUILD_DEP: numpy==1.10.4
-
-    - PYTHON: C:\Python34
-      PYTHON_VERSION: 3.4
-      PYTHON_ARCH: 32
-      NUMPY_BUILD_DEP: numpy==1.10.4
-
-    - PYTHON: C:\Python34-x64
-      PYTHON_VERSION: 3.4
-      PYTHON_ARCH: 64
-      NUMPY_BUILD_DEP: numpy==1.10.4
-
-    - PYTHON: C:\Python27
-      PYTHON_VERSION: 2.7
-      PYTHON_ARCH: 32
-      NUMPY_BUILD_DEP: numpy==1.10.4
-
-    - PYTHON: C:\Python27-x64
-      PYTHON_VERSION: 2.7
-      PYTHON_ARCH: 64
-      NUMPY_BUILD_DEP: numpy==1.10.4
+      NUMPY_BUILD_DEP: numpy==1.13.3
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"


### PR DESCRIPTION
- Do not build wheels for Python 2.7 and Python 3.4
- Increase NumPy minimum version to 1.13.3.