### PR TITLE
Update openblas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ env:
         # Also see DAILY_COMMIT below
         - BUILD_COMMIT=722bfc3f
         - PLAT=x86_64
-        - NP_BUILD_DEP="numpy==1.8.2"
+        - NP_BUILD_DEP="numpy==1.13.3"
         - CYTHON_BUILD_DEP="Cython==0.29.0"
-        - NP_TEST_DEP="numpy==1.8.2"
+        - NP_TEST_DEP="numpy==1.13.3"
         - UNICODE_WIDTH=32
         - MANYLINUX_URL="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
         - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
@@ -31,52 +31,26 @@ matrix:
   include:
     - os: linux
       env:
-        - MB_PYTHON_VERSION=2.7
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - UNICODE_WIDTH=16
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - PLAT=i686
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - PLAT=i686
-        - UNICODE_WIDTH=16
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.4
-        # Python 3.4 needs more recent numpy (for testing only)
-        - NP_TEST_DEP=numpy==1.9.3
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.4
-        - PLAT=i686
-        - NP_TEST_DEP=numpy==1.9.3
-    - os: linux
-      env:
         - MB_PYTHON_VERSION=3.5
-        - NP_BUILD_DEP=numpy==1.9.3
-        - NP_TEST_DEP=numpy==1.9.3
+        - NP_BUILD_DEP=numpy==1.13.3
+        - NP_TEST_DEP=numpy==1.13.3
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.5
         - PLAT=i686
-        - NP_BUILD_DEP=numpy==1.9.3
-        - NP_TEST_DEP=numpy==1.9.3
+        - NP_BUILD_DEP=numpy==1.13.3
+        - NP_TEST_DEP=numpy==1.13.3
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
-        - NP_BUILD_DEP=numpy==1.11.3
-        - NP_TEST_DEP=numpy==1.11.3
+        - NP_BUILD_DEP=numpy==1.13.3
+        - NP_TEST_DEP=numpy==1.13.3
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
         - PLAT=i686
-        - NP_BUILD_DEP=numpy==1.11.3
-        - NP_TEST_DEP=numpy==1.11.3
+        - NP_BUILD_DEP=numpy==1.13.3
+        - NP_TEST_DEP=numpy==1.13.3
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.7
@@ -93,27 +67,15 @@ matrix:
     - os: osx
       language: generic
       env:
-        - MB_PYTHON_VERSION=2.7
-    - os: osx
-      language: generic
-      env:
-        - MB_PYTHON_VERSION=3.4
-        - NP_TEST_DEP=numpy==1.9.3
-    - os: osx
-      language: generic
-      env:
         - MB_PYTHON_VERSION=3.5
-        # OSX build of scipy on Python 3.5 needs built 1.8.2 wheel to avoid
-        # https://github.com/numpy/numpy/issues/6204.  numpy 1.8.2 wheel for
-        # Python 3.5 at nipy manylinux URL.
-        - NP_BUILD_DEP=numpy==1.8.2
-        - NP_TEST_DEP=numpy==1.9.3
+        - NP_BUILD_DEP=numpy==1.13.3
+        - NP_TEST_DEP=numpy==1.13.3
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.6
-        - NP_BUILD_DEP=numpy==1.11.3
-        - NP_TEST_DEP=numpy==1.11.3
+        - NP_BUILD_DEP=numpy==1.13.3
+        - NP_TEST_DEP=numpy==1.13.3
     - os: osx
       language: generic
       env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
       OPENBLAS_32_SHA256: 4d8ebb7deb23e9aa39837087a8e41ac4cc0c0e44fa60861e1568e974bdbd7be6
       OPENBLAS_64_SHA256: e1bea2d94fe1c54c3cd1da62440a7975826427bc2dd55e67d064059632ddf323
       CYTHON_BUILD_DEP: Cython==0.29.0
-      NUMPY_TEST_DEP: numpy==1.13.1
+      NUMPY_TEST_DEP: numpy==1.13.3
       TEST_MODE: fast
       APPVEYOR_SAVE_CACHE_ON_ERROR: true
       APPVEYOR_SKIP_FINALIZE_ON_EXIT: true
@@ -46,42 +46,22 @@ environment:
     - PYTHON: C:\Python36
       PYTHON_VERSION: 3.6
       PYTHON_ARCH: 32
-      NUMPY_BUILD_DEP: numpy==1.12.1
+      NUMPY_BUILD_DEP: numpy==1.13.3
 
     - PYTHON: C:\Python36-x64
       PYTHON_VERSION: 3.6
       PYTHON_ARCH: 64
-      NUMPY_BUILD_DEP: numpy==1.12.1
+      NUMPY_BUILD_DEP: numpy==1.13.3
 
     - PYTHON: C:\Python35
       PYTHON_VERSION: 3.5
       PYTHON_ARCH: 32
-      NUMPY_BUILD_DEP: numpy==1.10.4
+      NUMPY_BUILD_DEP: numpy==1.13.3
 
     - PYTHON: C:\Python35-x64
       PYTHON_VERSION: 3.5
       PYTHON_ARCH: 64
-      NUMPY_BUILD_DEP: numpy==1.10.4
-
-    - PYTHON: C:\Python34
-      PYTHON_VERSION: 3.4
-      PYTHON_ARCH: 32
-      NUMPY_BUILD_DEP: numpy==1.10.4
-
-    - PYTHON: C:\Python34-x64
-      PYTHON_VERSION: 3.4
-      PYTHON_ARCH: 64
-      NUMPY_BUILD_DEP: numpy==1.10.4
-
-    - PYTHON: C:\Python27
-      PYTHON_VERSION: 2.7
-      PYTHON_ARCH: 32
-      NUMPY_BUILD_DEP: numpy==1.10.4
-
-    - PYTHON: C:\Python27-x64
-      PYTHON_VERSION: 2.7
-      PYTHON_ARCH: 64
-      NUMPY_BUILD_DEP: numpy==1.10.4
+      NUMPY_BUILD_DEP: numpy==1.13.3
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,10 @@ environment:
   global:
       MINGW_32: C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin
       MINGW_64: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
-      OPENBLAS_32: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.0-win32-gcc_7_1_0.zip"
-      OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.0-win_amd64-gcc_7_1_0.zip"
-      OPENBLAS_32_SHA256: 4d8ebb7deb23e9aa39837087a8e41ac4cc0c0e44fa60861e1568e974bdbd7be6
-      OPENBLAS_64_SHA256: e1bea2d94fe1c54c3cd1da62440a7975826427bc2dd55e67d064059632ddf323
+      OPENBLAS_32: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win32-gcc_7_1_0.zip"
+      OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win_amd64-gcc_7_1_0.zip"
+      OPENBLAS_32_SHA256: de77d0f239bca96b1c9206e1f59507559c7a4c98b1e11d3650c85827bb760666
+      OPENBLAS_64_SHA256: 1aad347e9232632b7e8ab785cdfcc5714be7f1193980b9115335c7b3bcdd993b
       CYTHON_BUILD_DEP: Cython==0.29.0
       NUMPY_TEST_DEP: numpy==1.13.3
       TEST_MODE: fast

--- a/env_vars.sh
+++ b/env_vars.sh
@@ -1,5 +1,5 @@
 # Environment variables for build
-OPENBLAS_VERSION="v0.3.0"
+OPENBLAS_VERSION="v0.3.3-186-g701ea883"
 MACOSX_DEPLOYMENT_TARGET=10.6
 
 # Enable Python fault handler on Pythons >= 3.3.

--- a/env_vars.sh
+++ b/env_vars.sh
@@ -1,6 +1,6 @@
 # Environment variables for build
 OPENBLAS_VERSION="v0.3.3-186-g701ea883"
-MACOSX_DEPLOYMENT_TARGET=10.6
+MACOSX_DEPLOYMENT_TARGET=10.9
 
 # Enable Python fault handler on Pythons >= 3.3.
 PYTHONFAULTHANDLER=1


### PR DESCRIPTION
Update to the fixed up v0.3.4 version, which is sadly named as being
v0.3.3. The newer library fixes many threading problems found in the
earlier version as well as other bugs, in particular https://github.com/scipy/scipy/issues/9620.

Note that this PR also upgrades the OS X deployment target from 10.6 to 10.9, which
is needed because the new OpenBLAS libraries target that version.