### PR TITLE
Update SciPy v1.2.x to OpenBLAS 3.4+

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,10 @@ environment:
   global:
       MINGW_32: C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin
       MINGW_64: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
-      OPENBLAS_32: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.0-win32-gcc_7_1_0.zip"
-      OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.0-win_amd64-gcc_7_1_0.zip"
-      OPENBLAS_32_SHA256: 4d8ebb7deb23e9aa39837087a8e41ac4cc0c0e44fa60861e1568e974bdbd7be6
-      OPENBLAS_64_SHA256: e1bea2d94fe1c54c3cd1da62440a7975826427bc2dd55e67d064059632ddf323
+      OPENBLAS_32: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win32-gcc_7_1_0.zip"
+      OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win_amd64-gcc_7_1_0.zip"
+      OPENBLAS_32_SHA256: de77d0f239bca96b1c9206e1f59507559c7a4c98b1e11d3650c85827bb760666
+      OPENBLAS_64_SHA256: 1aad347e9232632b7e8ab785cdfcc5714be7f1193980b9115335c7b3bcdd993b
       CYTHON_BUILD_DEP: Cython==0.29.0
       NUMPY_TEST_DEP: numpy==1.13.1
       TEST_MODE: fast

--- a/env_vars.sh
+++ b/env_vars.sh
@@ -1,6 +1,6 @@
 # Environment variables for build
-OPENBLAS_VERSION="v0.3.0"
-MACOSX_DEPLOYMENT_TARGET=10.6
+OPENBLAS_VERSION="v0.3.3-186-g701ea883"
+MACOSX_DEPLOYMENT_TARGET=10.9
 
 # Enable Python fault handler on Pythons >= 3.3.
 PYTHONFAULTHANDLER=1


### PR DESCRIPTION
Update to the fixed up v0.3.4 version, which is sadly named as being
v0.3.3. The newer library fixes many threading problems found in the
earlier version as well as other bugs, in particular https://github.com/scipy/scipy/issues/9620.

Note that this PR also upgrades the OS X deployment target from 10.6 to
10.9, which is needed because the new OpenBLAS libraries target that
version.