### PR TITLE
Add std=c99 flag to wheel build.

### DIFF
--- a/env_vars.sh
+++ b/env_vars.sh
@@ -1,6 +1,7 @@
 # Environment variables for build
 OPENBLAS_VERSION="v0.3.3-186-g701ea883"
 MACOSX_DEPLOYMENT_TARGET=10.9
+CFLAGS="-std=c99"
 
 # Enable Python fault handler on Pythons >= 3.3.
 PYTHONFAULTHANDLER=1


### PR DESCRIPTION
This is needed for the local declaration of loop variables. SciPy
does not do that currently, but this guarantees that if
they are used in the future a compiler error will not be raised.

Might also want to add `-fno-strict-aliasing` to the flags.