### PR TITLE
MAINT: bump min Cython version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
         - BUILD_COMMIT=master
         - PLAT=x86_64
         - NP_BUILD_DEP="numpy==1.13.3"
-        - CYTHON_BUILD_DEP="Cython==0.29.0"
+        - CYTHON_BUILD_DEP="Cython==0.29.2"
         - NP_TEST_DEP="numpy==1.13.3"
         - UNICODE_WIDTH=32
         - MANYLINUX_URL="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
       OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win_amd64-gcc_7_1_0.zip"
       OPENBLAS_32_SHA256: de77d0f239bca96b1c9206e1f59507559c7a4c98b1e11d3650c85827bb760666
       OPENBLAS_64_SHA256: 1aad347e9232632b7e8ab785cdfcc5714be7f1193980b9115335c7b3bcdd993b
-      CYTHON_BUILD_DEP: Cython==0.29.0
+      CYTHON_BUILD_DEP: Cython==0.29.2
       NUMPY_TEST_DEP: numpy==1.13.3
       TEST_MODE: fast
       APPVEYOR_SAVE_CACHE_ON_ERROR: true


### PR DESCRIPTION
Our master branch scipy wheels Travis cron jobs are failing because the pin to Cython `0.29.0` no longer meets our minimum requirement. For those jobs that are pinned to the minimum version, this PR should bump to the one we now require.

We don't have Appveyor cron jobs as far as I can tell, but there's a similar setting there that I've changed in the same way.