### PR TITLE
MAINT: bump OpenBLAS to 0.3.7.dev

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,10 @@ environment:
   global:
       MINGW_32: C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin
       MINGW_64: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
-      OPENBLAS_32: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win32-gcc_7_1_0.zip"
-      OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.3-186-g701ea883-win_amd64-gcc_7_1_0.zip"
-      OPENBLAS_32_SHA256: de77d0f239bca96b1c9206e1f59507559c7a4c98b1e11d3650c85827bb760666
-      OPENBLAS_64_SHA256: 1aad347e9232632b7e8ab785cdfcc5714be7f1193980b9115335c7b3bcdd993b
+      OPENBLAS_32: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-274-g6a8b4269-win32-gcc_7_1_0.zip"
+      OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.5-274-g6a8b4269-win_amd64-gcc_7_1_0.zip"
+      OPENBLAS_32_SHA256: 45339f90ba2490cba88beff050f7291ed6337a44af5f611c203fd4d5f7f9dadb
+      OPENBLAS_64_SHA256: 5a8875d76658cb5dc27d79ced7c66bd27d2356d52bdac9fbae2c1ee8b4b20750
       CYTHON_BUILD_DEP: Cython==0.29.2
       NUMPY_TEST_DEP: numpy==1.13.3
       TEST_MODE: fast

--- a/env_vars.sh
+++ b/env_vars.sh
@@ -1,5 +1,5 @@
 # Environment variables for build
-OPENBLAS_VERSION="v0.3.3-186-g701ea883"
+OPENBLAS_VERSION="v0.3.5-274-g6a8b4269"
 MACOSX_DEPLOYMENT_TARGET=10.9
 
 # Enable Python fault handler on Pythons >= 3.3.


### PR DESCRIPTION
* bump the version of OpenBLAS used
in SciPy wheel builds to match upstream
fixes for AVX kernel handling on SkylakeX
architecture (basically, they get turned off)

For more details, see the SciPy Intel SDE SkylakeX emulation CI run: https://github.com/scipy/scipy/pull/10145

I may have to seriously consider cherry-picking this to the 1.3.x wheels branch. Perhaps I can delay 1.2.x  LTS OpenBLAS bump for the time being though.