### PR TITLE
MAINT: remove some old Python content

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -176,13 +176,6 @@ build_script:
   - mkdir build\lib.win-amd64-3.5\scipy\extra-dll
   - copy "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x86\Microsoft.VC140.CRT\msvcp140.dll" "build\lib.win32-3.5\scipy\extra-dll\"
   - copy "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x64\Microsoft.VC140.CRT\msvcp140.dll" "build\lib.win-amd64-3.5\scipy\extra-dll\"
-  # * Python 3.4
-  #   Didn't find the redist libs on appveyor for MSVC 10.0; hopefully few people use this old Python.
-  # * Python 2.7
-  - mkdir build\lib.win32-2.7\scipy\extra-dll
-  - mkdir build\lib.win-amd64-2.7\scipy\extra-dll
-  - copy "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\redist\x86\Microsoft.VC90.CRT"\*.* "build\lib.win32-2.7\scipy\extra-dll\"
-  - copy "C:\Program Files (x86)\Microsoft Visual Studio 9.0\VC\redist\amd64\Microsoft.VC90.CRT"\*.* "build\lib.win-amd64-2.7\scipy\extra-dll\"
   # Build wheel using setup.py
   - ps: |
       $PYTHON_ARCH = $env:PYTHON_ARCH


### PR DESCRIPTION
Noticed this based on code highlighted by Pauli here: https://github.com/scipy/scipy/issues/10628

A follow-up PR may be needed if a decision is reached on the Python 3.7+ issue described there.

* remove some comments and code related
to versions of Python we no longer support;
the LTS Python 2.7 branch has its own wheels
branch that won't be affected by this

I suspect even more cleanup is possible depending on the 3.5 support timeline, but perhaps this is a conservative start.