### PR TITLE
MAINT: bundle msvcp140.dll always

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -160,22 +160,16 @@ build_script:
   - git checkout %BUILD_COMMIT%
   # Append license text relevant for the built wheel
   - type ..\LICENSE_win32.txt >> LICENSE.txt
-  # Copy over additional DLLs to bundle to the wheels
-  #
-  # The find commands below are mainly to find the paths where the libraries are.
+  # Copy over additional DLLs to bundle to the wheels.
+  # The find command below is just to print where the libraries are, for debugging.
   - C:\cygwin\bin\find "C:\Program Files (x86)\Microsoft Visual Studio 14.0" -type f -name 'msvcp*.dll'
-  - C:\cygwin\bin\find "C:\Program Files (x86)\Microsoft Visual Studio 10.0" -type f -name 'msvcp*.dll'
-  - C:\cygwin\bin\find "C:\Program Files (x86)\Microsoft Visual Studio 9.0" -type f -name 'msvcp*.dll'
-  # * Python 3.6
-  - mkdir build\lib.win32-3.6\scipy\extra-dll
-  - mkdir build\lib.win-amd64-3.6\scipy\extra-dll
-  - copy "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x86\Microsoft.VC140.CRT\msvcp140.dll" "build\lib.win32-3.6\scipy\extra-dll\"
-  - copy "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x64\Microsoft.VC140.CRT\msvcp140.dll" "build\lib.win-amd64-3.6\scipy\extra-dll\"
-  # * Python 3.5
-  - mkdir build\lib.win32-3.5\scipy\extra-dll
-  - mkdir build\lib.win-amd64-3.5\scipy\extra-dll
-  - copy "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x86\Microsoft.VC140.CRT\msvcp140.dll" "build\lib.win32-3.5\scipy\extra-dll\"
-  - copy "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x64\Microsoft.VC140.CRT\msvcp140.dll" "build\lib.win-amd64-3.5\scipy\extra-dll\"
+  # * Python >=3.5
+  # Copy over MSVC C++ runtime library, which Python.org does no bundle, but is required by us.
+  # The version should match the compiler version, see https://wiki.python.org/moin/WindowsCompilers
+  - mkdir "build\lib.win32-%PYTHON_VERSION%\scipy\extra-dll"
+  - mkdir "build\lib.win-amd64-%PYTHON_VERSION%\scipy\extra-dll"
+  - copy "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x86\Microsoft.VC140.CRT\msvcp140.dll" "build\lib.win32-%PYTHON_VERSION%\scipy\extra-dll\"
+  - copy "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x64\Microsoft.VC140.CRT\msvcp140.dll" "build\lib.win-amd64-%PYTHON_VERSION%\scipy\extra-dll\"
   # Build wheel using setup.py
   - ps: |
       $PYTHON_ARCH = $env:PYTHON_ARCH


### PR DESCRIPTION
All Python versions need the C++ CRT msvcp140.dll since it is not
shipped together with Python.org Python binary.

In principle, the use can download and install the MSVCRT runtime from
Microsoft (and often it is already installed as a part of some other program),
but there are cases where the library is not present already which leads to
the generic "DLL load failed" error message which is hard to debug.

In appveyor.yml the copying was done separately for different Python versions,
because it used to be the case that they used different versions of MSVC.
However, the current versions all use MSVC 14.0.

Closes: https://github.com/scipy/scipy/issues/10628