### PR TITLE
Fix py35-osx build on travis

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -76,3 +76,14 @@ function run_tests {
     # Show BLAS / LAPACK used
     python -c 'import scipy; scipy.show_config()'
 }
+
+function install_run {
+    # Override multibuild test running command, to preinstall packages
+    # that have to be installed before TEST_DEPENDS.
+    pip install $(pip_opts) setuptools_scm
+
+    # Copypaste from multibuild/common_utils.sh:install_run
+    install_wheel
+    mkdir tmp_for_test
+    (cd tmp_for_test && run_tests)
+}


### PR DESCRIPTION
The build fails when trying to install pytest-forked included via
TEST_DEPENDS, when it tries to easy-install via setup_requires the
setuptools_scm package, encountering some TLS download errors.  Work
around this by pre-installing the package via pip.