### PR TITLE
MAINT: bump Cython for Travis wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
         - BUILD_COMMIT=master
         - PLAT=x86_64
         - NP_BUILD_DEP="numpy==1.13.3"
-        - CYTHON_BUILD_DEP="Cython==0.29.2"
+        - CYTHON_BUILD_DEP="Cython==0.29.13"
         - PYBIND11_BUILD_DEP="pybind11==2.3.0"
         - NP_TEST_DEP="numpy==1.13.3"
         - UNICODE_WIDTH=32

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
       OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.7-win_amd64-gcc_7_1_0.zip"
       OPENBLAS_32_SHA256: 5272f4acc06acd79b02b99d193ef94036ba6042966638fcd5548c70537bcabdd
       OPENBLAS_64_SHA256: 4d496081543c61bfb8069c1a12dfc2c0371cf9c59f9a4488e2e416dd4026357e
-      CYTHON_BUILD_DEP: Cython==0.29.2
+      CYTHON_BUILD_DEP: Cython==0.29.13
       NUMPY_TEST_DEP: numpy==1.13.3
       PYBIND11_BUILD_DEP: pybind11==2.3.0
       TEST_MODE: fast


### PR DESCRIPTION
* four of the master branch SciPy wheels
Travis CI matrix entries are erroring with
a message: "Building SciPy requires Cython >= 0.29.13, found 0.29.2"

* so, bumping Cython to 0.29.13 in an attempt to
fix this error

Note that I'd still expect those jobs to fail, but SciPy should at least build if this helps. There appears to be another issue even if Cython is updated.