### PR TITLE
DLL handling fixes for 1.3.x

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -196,10 +196,10 @@ build_script:
   # * Python >=3.5
   # Copy over MSVC C++ runtime library, which Python.org does no bundle, but is required by us.
   # The version should match the compiler version, see https://wiki.python.org/moin/WindowsCompilers
-  - mkdir "build\lib.win32-%PYTHON_VERSION%\scipy\extra-dll"
-  - mkdir "build\lib.win-amd64-%PYTHON_VERSION%\scipy\extra-dll"
-  - copy "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x86\Microsoft.VC140.CRT\msvcp140.dll" "build\lib.win32-%PYTHON_VERSION%\scipy\extra-dll\"
-  - copy "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x64\Microsoft.VC140.CRT\msvcp140.dll" "build\lib.win-amd64-%PYTHON_VERSION%\scipy\extra-dll\"
+  - mkdir "build\lib.win32-%PYTHON_VERSION%\scipy\.libs"
+  - mkdir "build\lib.win-amd64-%PYTHON_VERSION%\scipy\.libs"
+  - copy "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x86\Microsoft.VC140.CRT\msvcp140.dll" "build\lib.win32-%PYTHON_VERSION%\scipy\.libs\"
+  - copy "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\redist\x64\Microsoft.VC140.CRT\msvcp140.dll" "build\lib.win-amd64-%PYTHON_VERSION%\scipy\.libs\"
   # Build wheel using setup.py
   - ps: |
       $PYTHON_ARCH = $env:PYTHON_ARCH

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -236,7 +236,7 @@ test_script:
   - cd ..
   - mkdir tmp_test
   - cd tmp_test
-  - python ..\check_license.py
+  - python ..\check_installed_package.py
   - python ..\run_scipy_tests.py %TEST_MODE% -- -n6 --junitxml=%cd%\junit-results.xml -rfEX
 
 after_test:

--- a/check_installed_package.py
+++ b/check_installed_package.py
@@ -32,10 +32,10 @@ def check_dll_paths(mod):
     for filename in Path(install_basedir).rglob('*.dll'):
         list_filepaths.append(filename)
 
-    reference_basepath = os.path.dirname(list_filepaths.pop(0))
+    reference_basepath = os.path.dirname(str(list_filepaths.pop(0)))
 
     for filepath in list_filepaths:
-        if os.path.dirname(filepath) != reference_basepath:
+        if os.path.dirname(str(filepath)) != reference_basepath:
             print("mismatch between current DLL file path: ",
                    filepath,
                    "and the reference file path for packaged DLLs: ",

--- a/check_installed_package.py
+++ b/check_installed_package.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python
 """
-check_license.py [MODULE]
+check_installed_package.py [MODULE]
 
 Check the presence of a LICENSE.txt in the installed module directory,
 and that it appears to contain text prevalent for a Scipy binary
 distribution.
+
+On Windows, also check that all DLLs packaged in the SciPy
+wheel reside at the same path---see gh-57.
 
 """
 import os
@@ -12,6 +15,7 @@ import sys
 import io
 import re
 import argparse
+import platform
 from pathlib import Path
 
 def check_text(text):
@@ -65,7 +69,9 @@ def main():
         sys.exit(1)
 
 
-    check_dll_paths(mod)
+    if platform.system() == 'Windows':
+        check_dll_paths(mod)
+
     sys.exit(0)
 
 

--- a/config.sh
+++ b/config.sh
@@ -70,7 +70,7 @@ function run_tests {
         local testmode="fast"
     fi
     # Check bundled license file
-    python ../check_license.py
+    python ../check_installed_package.py
     # Run tests
     python ../run_scipy_tests.py $testmode -- -n2 -rfEX
     # Show BLAS / LAPACK used


### PR DESCRIPTION
The fixes from #58 are needed for the `1.3.x` wheels branch as well.