### PR TITLE
MAINT: update OpenBLAS sha256

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ environment:
       MINGW_64: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
       OPENBLAS_32: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.7-win32-gcc_7_1_0.zip"
       OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.7-win_amd64-gcc_7_1_0.zip"
-      OPENBLAS_32_SHA256: 5272f4acc06acd79b02b99d193ef94036ba6042966638fcd5548c70537bcabdd
+      OPENBLAS_32_SHA256: 06e3d38f01119afe5d6630d7ad310a873f8bede52fe71f2d0e2ebf3476194892
       OPENBLAS_64_SHA256: 4d496081543c61bfb8069c1a12dfc2c0371cf9c59f9a4488e2e416dd4026357e
       CYTHON_BUILD_DEP: Cython==0.29.13
       NUMPY_TEST_DEP: numpy==1.13.3


### PR DESCRIPTION
* upstream work in openblas-libs accidentally
regenerated at least a few of the zip files
we use from rackspace for OpenBLAS v0.3.7 in wheel
build workflows; adjust the sha256 in those
cases where failures were recently observed
due to mismatches

Reference log with only 32-bit Windows sha256 mismatches: https://ci.appveyor.com/project/scipy/scipy-wheels/builds/29611388