### PR TITLE
MAINT: Windows/Appveyor updates

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ environment:
       OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.7-win_amd64-gcc_7_1_0.zip"
       OPENBLAS_32_SHA256: 06e3d38f01119afe5d6630d7ad310a873f8bede52fe71f2d0e2ebf3476194892
       OPENBLAS_64_SHA256: 4d496081543c61bfb8069c1a12dfc2c0371cf9c59f9a4488e2e416dd4026357e
-      CYTHON_BUILD_DEP: Cython==0.29.13
+      CYTHON_BUILD_DEP: Cython==0.29.14
       NUMPY_TEST_DEP: numpy==1.13.3
       PYBIND11_BUILD_DEP: pybind11==2.4.3
       TEST_MODE: fast
@@ -65,16 +65,6 @@ environment:
 
     - PYTHON: C:\Python36-x64
       PYTHON_VERSION: 3.6
-      PYTHON_ARCH: 64
-      NUMPY_BUILD_DEP: numpy==1.13.3
-
-    - PYTHON: C:\Python35
-      PYTHON_VERSION: 3.5
-      PYTHON_ARCH: 32
-      NUMPY_BUILD_DEP: numpy==1.13.3
-
-    - PYTHON: C:\Python35-x64
-      PYTHON_VERSION: 3.5
       PYTHON_ARCH: 64
       NUMPY_BUILD_DEP: numpy==1.13.3
 


### PR DESCRIPTION
* scipy-wheels master branch Appveyor builds
are failing for Python 3.6 because Cython is
pinned to 0.29.13; this PR bumps to the required
0.29.14

* SciPy master branch no longer supports Python 3.5,
so remove these two builds from the Appveyor
matrix