### PR TITLE
MAINT: unpin MacOS PY37 multibuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,13 +100,6 @@ before_install:
       fi
     - BUILD_DEPENDS="$NP_BUILD_DEP $CYTHON_BUILD_DEP $PYBIND11_BUILD_DEP"
     - TEST_DEPENDS="$NP_TEST_DEP pytest pytest-xdist pytest-faulthandler pytest-env"
-    - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-        if [ "$MB_PYTHON_VERSION" == "3.7" ]; then  
-            cd multibuild;
-            git checkout 65fd07a180046b4473b21e9084e01f1bf1a8dfac;
-            cd ..;
-        fi
-      fi
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh
     - before_install


### PR DESCRIPTION
* MacOS Python 3.7 wheel builds were
recently pinned to an older version
of multibuild in the main & wheels repos
for SciPy

* it was possible to build successfully
in main repo after unpinning multibuild
for the same Mac OS Python version
in: https://github.com/scipy/scipy/pull/11419

* so, unpin multibuild for MacOS Python 3.7
in the wheels repo to enable pip20 support,
etc.

One or two minor adjustments may be needed to get this working
just right --- a spurious version of gcc had to be removed
in https://github.com/scipy/scipy/pull/11419 for example