### PR TITLE
Anaconda org weekly upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,13 +112,15 @@ script:
     - install_run $PLAT
 
 after_success:
-    # Upload wheels to Rackspace container
-    # Upload may not work for Python 3.7:
-    # https://github.com/ogrisel/wheelhouse-uploader/issues/27
-    - pip install wheelhouse-uploader
-    # disable uploads because we have lost free hosting
-    # with Rackspace:
-    #- travis_wait python -m wheelhouse_uploader upload --local-folder
-    #     ${TRAVIS_BUILD_DIR}/wheelhouse/
-    #     $UPLOAD_ARGS
-    #     $CONTAINER
+    # trigger an upload to the shared ecosystem
+    # infrastructure at: https://anaconda.org/scipy-wheels-nightly
+    # for cron jobs only (restricted to master branch once
+    # per week)
+    # SCIPY_WHEELS_NIGHTLY is a secret token
+    # used in Travis CI config, originally
+    # generated at anaconda.org for scipy-wheels-nightly
+    - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+          ANACONDA_ORG="scipy-wheels-nightly";
+          pip install git+https://github.com/Anaconda-Server/anaconda-client
+          anaconda -t ${SCIPY_WHEELS_NIGHTLY} upload --force -u ${ANACONDA_ORG} ${TRAVIS_BUILD_DIR}/wheelhouse/*.whl;
+      fi


### PR DESCRIPTION
Supersedes #68 because testing the secret API key for anaconda.org uploads likely requires that the feature branch originates in the repo itself.

Don't merge yet---still in a debug state with matrix largely commented out.