### PR TITLE
MAINT: appveyor rack->conda.org

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,6 @@ environment:
   global:
       MINGW_32: C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin
       MINGW_64: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
-      OPENBLAS_32: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.7-win32-gcc_7_1_0.zip"
-      OPENBLAS_64: "https://3f23b170c54c2533c070-1c8a9b3114517dc5fe17b7c3f8c63a43.ssl.cf2.rackcdn.com/openblas-v0.3.7-win_amd64-gcc_7_1_0.zip"
-      OPENBLAS_32_SHA256: 06e3d38f01119afe5d6630d7ad310a873f8bede52fe71f2d0e2ebf3476194892
-      OPENBLAS_64_SHA256: 4d496081543c61bfb8069c1a12dfc2c0371cf9c59f9a4488e2e416dd4026357e
       CYTHON_BUILD_DEP: Cython==0.29.14
       NUMPY_TEST_DEP: numpy==1.14.5
       PYBIND11_BUILD_DEP: pybind11==2.4.3
@@ -111,36 +107,12 @@ install:
   - ps: |
       $PYTHON_ARCH = $env:PYTHON_ARCH
       $PYTHON = $env:PYTHON
-      If ($PYTHON_ARCH -eq 32) {
-          $OPENBLAS = $env:OPENBLAS_32
-          $OPENBLAS_SHA256 = $env:OPENBLAS_32_SHA256
-      } Else {
-          $OPENBLAS = $env:OPENBLAS_64
-          $OPENBLAS_SHA256 = $env:OPENBLAS_64_SHA256
-      }
-      $clnt = new-object System.Net.WebClient
-      $file = "$(New-TemporaryFile).zip"
-      $tmpdir = New-TemporaryFile | %{ rm $_; mkdir $_ }
+
+      cd scipy
+      git checkout $env:BUILD_COMMIT
+      $lib = python tools/openblas_support.py
+      cd ..
       $destination = "$PYTHON\lib\openblas.a"
-
-      echo $file
-      echo $tmpdir
-      echo $OPENBLAS
-
-      $clnt.DownloadFile($OPENBLAS,$file)
-
-      $downloaded_hash = Get-FileHash -Algorithm SHA256 $file
-      if ($downloaded_hash.hash -ne $OPENBLAS_SHA256) {
-          $downloaded_hash | Format-List
-          echo $OPENBLAS_SHA256
-          throw "Downloaded OPENBLAS zip SHA256 does not match."
-      }
-
-      Expand-Archive $file $tmpdir
-
-      rm $tmpdir\$PYTHON_ARCH\lib\*.dll.a
-      $lib = ls $tmpdir\$PYTHON_ARCH\lib\*.a | ForEach { ls $_ } | Select-Object -first 1
-      echo $lib
 
       cp $lib $destination
       ls $destination
@@ -163,12 +135,9 @@ install:
       }
 
 build_script:
-  - cd scipy
-  - git checkout %BUILD_COMMIT%
   # we use a distribution file to assist in loading
   # DLLs
   - ps: |
-      cd ..
       $cwd = Get-Location
       ls $cwd
       rm -Force $cwd/scipy/scipy/_distributor_init.py


### PR DESCRIPTION
* switch to using `anaconda.org` for OpenBLAS downloads
in our Windows wheel build infrastructure to avoid future
charges from Rackspace to OSS community

* this involves offloading most of the download logic
to `tools/openblas_support.py`

@mattip @pv @rgommers Any security concerns with removal of the hash checking here? Does that need to be added to `openblas_support.py` in the main repo?