### PR TITLE
MAINT: add Travis staging uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,24 @@
 tmp_for_test/
 working/
 build/
+
+# for vim:
+# Swap
+[._]*.s[a-v][a-z]
+!*.svg  # comment out if you don't need vector files
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+*~
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,3 +124,12 @@ after_success:
           pip install git+https://github.com/Anaconda-Server/anaconda-client
           anaconda -t ${SCIPY_WHEELS_NIGHTLY} upload --force -u ${ANACONDA_ORG} ${TRAVIS_BUILD_DIR}/wheelhouse/*.whl;
       fi
+    # for merges (push events) we use the staging area instead;
+    # SCIPY_STAGING_UPLOAD_TOKEN is a secret token used in Travis
+    # CI config, originally generated at anaconda.org for
+    # multibuild-wheels-staging
+    - if [ "$TRAVIS_EVENT_TYPE" == "push" ]; then
+          ANACONDA_ORG="multibuild-wheels-staging";
+          pip install git+https://github.com/Anaconda-Server/anaconda-client
+          anaconda -t ${SCIPY_STAGING_UPLOAD_TOKEN} upload --force -u ${ANACONDA_ORG} ${TRAVIS_BUILD_DIR}/wheelhouse/*.whl;
+      fi


### PR DESCRIPTION
* for merges (pushes) into `master` and other feature
branches (i.e., release branches), add Travis CI code
to upload to `multibuild-wheels-staging` area, which
would be used for staging before releases, etc.

* update `.gitignore` with standard vim tags from
`github/gitignore` repo, so I don't have to look
at swap files in my staging area

@mattip @ogrisel @rgommers 

Note that the  `multibuild-wheels-staging` storage is already looking close to full, and SciPy hasn't even started using this resource:

![image](https://user-images.githubusercontent.com/7903078/81512607-fc35ca00-92de-11ea-8e97-ee2d1c443a40.png)
