### PR TITLE
MAINT: use `openblas_support.py` for Travis

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -17,12 +17,11 @@ function build_wheel {
 }
 
 function build_libs {
-    local plat=${1:-$PLAT}
-    local tar_path=$(abspath $(get_gf_lib "openblas-${OPENBLAS_VERSION}" "$plat"))
-    # Sudo needed for macOS
-    local use_sudo=""
-    [ -n "$IS_OSX" ] && use_sudo="sudo"
-    (cd / && $use_sudo tar zxf $tar_path)
+    PYTHON_EXE=`which python`
+    $PYTHON_EXE -c"import platform; print('platform.uname().machine', platform.uname().machine)"
+    basedir=$($PYTHON_EXE scipy/tools/openblas_support.py)
+    $use_sudo cp -r $basedir/lib/* /usr/local/lib
+    $use_sudo cp $basedir/include/* /usr/local/include
 }
 
 function set_arch {

--- a/env_vars.sh
+++ b/env_vars.sh
@@ -1,5 +1,4 @@
 # Environment variables for build
-OPENBLAS_VERSION="v0.3.7"
 MACOSX_DEPLOYMENT_TARGET=10.9
 
 # Enable Python fault handler on Pythons >= 3.3.


### PR DESCRIPTION
Fixes #72 

* Appveyor CI wheel builds already use `openblas_support.py`; use the
same script for `OpenBLAS` dependency handling in Travis CI for
wheel builds

* this approach is based on the one described by @mattip for
NumPy wheels in the cognate issue, except that for SciPy we should
not need `urllib3` because of our different approaches to file
downloading in `openblas_support.py`

@rgommers @pv Note that this means `OpenBLAS` version bumps have to happen through merges to the maintenance branch via changes to `openblas_support.py` rather than setting an ENV variable in the wheels repo to bump the version.