### PR TITLE
MAINT: bump Cython to min required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
         - BUILD_COMMIT=master
         - PLAT=x86_64
         - NP_BUILD_DEP="numpy==1.14.5"
-        - CYTHON_BUILD_DEP="Cython==0.29.14"
+        - CYTHON_BUILD_DEP="Cython==0.29.18"
         - PYBIND11_BUILD_DEP="pybind11==2.4.3"
         - NP_TEST_DEP="numpy==1.14.5"
         - UNICODE_WIDTH=32

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
   global:
       MINGW_32: C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin
       MINGW_64: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
-      CYTHON_BUILD_DEP: Cython==0.29.14
+      CYTHON_BUILD_DEP: Cython==0.29.18
       NUMPY_TEST_DEP: numpy==1.14.5
       PYBIND11_BUILD_DEP: pybind11==2.4.3
       TEST_MODE: fast


### PR DESCRIPTION
* the minimum required Cython version to build
SciPy is now `0.29.18`; this change has been pushed
directly to the `v1.5.x` wheels feature branch because
of observed failures there, so this is effectively
a forward-port of that