### PR TITLE
MAINT: timestamp nightlies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,6 +120,8 @@ after_success:
     # used in Travis CI config, originally
     # generated at anaconda.org for scipy-wheels-nightly
     - if [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then
+          source extra_functions.sh;
+          for f in wheelhouse/*.whl; do rename_wheel $f; done;
           ANACONDA_ORG="scipy-wheels-nightly";
           pip install git+https://github.com/Anaconda-Server/anaconda-client;
           anaconda -t ${SCIPY_WHEELS_NIGHTLY} upload --force -u ${ANACONDA_ORG} ${TRAVIS_BUILD_DIR}/wheelhouse/*.whl;

--- a/extra_functions.sh
+++ b/extra_functions.sh
@@ -1,0 +1,14 @@
+function rename_wheel {
+    # Call with a name like scipy-1.5.0.dev0+58dbafa-cp37-cp37m-linux_x86_64.whl
+
+    # Add a date after the dev0+ and before the hash in yyymmddHHMMSS format
+    # so pip will pick up the newest build. Try a little to make sure
+    # - the first part ends with 'dev0+'
+    # - the second part starts with a lower case alphanumeric then a '-'
+    # if those conditions are not met, the name will be returned as-is
+
+    newname=$(echo "$1" | sed "s/\(.*dev0+\)\([a-z0-9]*-.*\)/\1$(date '+%Y%m%d%H%M%S_')\2/")
+    if [ "$newname" != "$1" ]; then
+        mv $1 $newname
+    fi
+}


### PR DESCRIPTION
* as outlined in gh-77, downstream projects will have
a hard time automatically downloading our most recent
"nightly" (actually weekly) wheel uploads if we don't
add a timestamp of sorts

* this patch attempts to "borrow" the machinery added by
Matti in https://github.com/MacPython/numpy-wheels/pull/84
for this purpose

I believe this has already impacted one project for @bashtage

cc @mattip @rgommers 

I don't want this to automatically `close` gh-77 because we should check the next nightly upload filenames once this is ready & merged (weekly uploads happen on Tuesdays, for POSIX platforms only)