### PR TITLE
BLD, MAINT: pin setuptools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
         - NP_BUILD_DEP="numpy==1.14.5"
         - CYTHON_BUILD_DEP="Cython==0.29.18"
         - PYBIND11_BUILD_DEP="pybind11==2.4.3"
+        - SETUPTOOLS_BUILD_DEP="setuptools!=49.2.0"
         - NP_TEST_DEP="numpy==1.14.5"
         - UNICODE_WIDTH=32
         - MANYLINUX_URL="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
@@ -96,7 +97,7 @@ before_install:
           CONTAINER=wheels;
           UPLOAD_ARGS="--no-update-index";
       fi
-    - BUILD_DEPENDS="$NP_BUILD_DEP $CYTHON_BUILD_DEP $PYBIND11_BUILD_DEP"
+    - BUILD_DEPENDS="$NP_BUILD_DEP $CYTHON_BUILD_DEP $PYBIND11_BUILD_DEP $SETUPTOOLS_BUILD_DEP"
     - TEST_DEPENDS="$NP_TEST_DEP pytest pytest-xdist pytest-faulthandler pytest-env"
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh


### PR DESCRIPTION
* attempt to avoid the SciPy main repo issue:
https://github.com/scipy/scipy/issues/12579

* normally we open wheels repo fixes to `master` branch,
but let's first just see if pinning `setuptools!=49.2.0`
can alleviate the SciPy `1.5.2` wheel build failures that
are observed on Linux only, as described above (a similar
strategy has recently been used in NumPy when these warnings
were observed there)

cc @rgommers @pv @mattip 

I'm not really sure why this is observed Linux-only, but the level of abstraction with shell scripts sourcing other shell functions through `multibuild` could mean that a  slightly different code path might be exercised for Linux `pip` commands or something like that.