### PR TITLE
MAINT: ARM64 & related backports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,24 @@ jobs:
       # Exclude the default Python 3.5 build
       - python: 3.5
   include:
+    - stage: Build and test wheel
+      os: linux
+      arch: arm64
+      env:
+        - MB_PYTHON_VERSION=3.7
+        - PLAT=aarch64
+        - NP_BUILD_DEP=numpy==1.19.1
+        - CYTHON_BUILD_DEP="Cython"
+        - DOCKER_IMAGE=quay.io/pypa/manylinux2014_${PLAT}
+      script:
+        - echo "This stage will just build AArch64 wheel"
+      workspaces:
+        create:
+          name: ws1
+          paths:
+            - wheelhouse
+      after_success:
+        - echo "This stage will not upload aarch64 wheel"
     - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
@@ -87,6 +105,19 @@ jobs:
         - NP_TEST_DEP=numpy==1.17.3
         - CYTHON_BUILD_DEP="Cython"
         - MB_PYTHON_OSX_VER=10.9
+
+    - stage: Test wheel
+      arch: arm64
+      env:
+        - MB_PYTHON_VERSION=3.7
+        - PLAT=aarch64
+        - NP_TEST_DEP=numpy==1.19.1
+        - CYTHON_BUILD_DEP="Cython"
+        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+      workspaces:
+        use: ws1
+      install:
+        - echo "This stage will test and upload the AArch64 wheel"
 
 before_install:
     - if [ "$TRAVIS_BRANCH" == "master" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,46 @@ jobs:
       after_success:
         - echo "This stage will not upload aarch64 wheel"
     - os: linux
+      arch: arm64-graviton2
+      dist: focal
+      virt: vm
+      group: edge
+      env:
+        - MB_PYTHON_VERSION=3.6
+        - PLAT=aarch64
+        - NP_BUILD_DEP=numpy==1.19.1
+        - CYTHON_BUILD_DEP="Cython"
+        - DOCKER_IMAGE=quay.io/pypa/manylinux2014_${PLAT}
+      script:
+        - echo "This stage will just build AArch64 wheel"
+      workspaces:
+        create:
+          name: ws2
+          paths:
+            - wheelhouse
+      after_success:
+        - echo "This stage will not upload aarch64 wheel"
+    - os: linux
+      arch: arm64-graviton2
+      dist: focal
+      virt: vm
+      group: edge
+      env:
+        - MB_PYTHON_VERSION=3.8
+        - PLAT=aarch64
+        - NP_BUILD_DEP=numpy==1.19.1
+        - CYTHON_BUILD_DEP="Cython"
+        - DOCKER_IMAGE=quay.io/pypa/manylinux2014_${PLAT}
+      script:
+        - echo "This stage will just build AArch64 wheel"
+      workspaces:
+        create:
+          name: ws3
+          paths:
+            - wheelhouse
+      after_success:
+        - echo "This stage will not upload aarch64 wheel"
+    - os: linux
       env:
         - MB_PYTHON_VERSION=3.6
         - NP_BUILD_DEP=numpy==1.14.5
@@ -122,6 +162,34 @@ jobs:
         - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
       workspaces:
         use: ws1
+      install:
+        - echo "This stage will test and upload the AArch64 wheel"
+    - arch: arm64-graviton2
+      dist: focal
+      virt: vm
+      group: edge
+      env:
+        - MB_PYTHON_VERSION=3.6
+        - PLAT=aarch64
+        - NP_TEST_DEP=numpy==1.19.1
+        - CYTHON_BUILD_DEP="Cython"
+        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+      workspaces:
+        use: ws2
+      install:
+        - echo "This stage will test and upload the AArch64 wheel"
+    - arch: arm64-graviton2
+      dist: focal
+      virt: vm
+      group: edge
+      env:
+        - MB_PYTHON_VERSION=3.8
+        - PLAT=aarch64
+        - NP_TEST_DEP=numpy==1.19.1
+        - CYTHON_BUILD_DEP="Cython"
+        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+      workspaces:
+        use: ws3
       install:
         - echo "This stage will test and upload the AArch64 wheel"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,10 @@ jobs:
   include:
     - stage: Build and test wheel
       os: linux
-      arch: arm64
+      arch: arm64-graviton2
+      dist: focal
+      virt: vm
+      group: edge
       env:
         - MB_PYTHON_VERSION=3.7
         - PLAT=aarch64
@@ -107,7 +110,10 @@ jobs:
         - MB_PYTHON_OSX_VER=10.9
 
     - stage: Test wheel
-      arch: arm64
+      arch: arm64-graviton2
+      dist: focal
+      virt: vm
+      group: edge
       env:
         - MB_PYTHON_VERSION=3.7
         - PLAT=aarch64

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
     global:
         - REPO_DIR=scipy
         # Also see DAILY_COMMIT below
-        - BUILD_COMMIT=01d8bfb
+        - BUILD_COMMIT=c72ad0c
         - PLAT=x86_64
         - NP_BUILD_DEP="numpy==1.14.5"
         - CYTHON_BUILD_DEP="Cython==0.29.18"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ jobs:
       - python: 3.5
   include:
     - stage: Build and test wheel
+      name: ARM64-Linux-Py37
       os: linux
       arch: arm64-graviton2
       dist: focal
@@ -50,6 +51,7 @@ jobs:
       after_success:
         - echo "This stage will not upload aarch64 wheel"
     - os: linux
+      name: ARM64-Linux-Py36
       arch: arm64-graviton2
       dist: focal
       virt: vm
@@ -70,6 +72,7 @@ jobs:
       after_success:
         - echo "This stage will not upload aarch64 wheel"
     - os: linux
+      name: ARM64-Linux-Py38
       arch: arm64-graviton2
       dist: focal
       virt: vm
@@ -90,29 +93,34 @@ jobs:
       after_success:
         - echo "This stage will not upload aarch64 wheel"
     - os: linux
+      name: amd64-Linux-Py36
       env:
         - MB_PYTHON_VERSION=3.6
         - NP_BUILD_DEP=numpy==1.14.5
         - NP_TEST_DEP=numpy==1.14.5
     - os: linux
+      name: 32bit-amd64-Linux-Py36
       env:
         - MB_PYTHON_VERSION=3.6
         - PLAT=i686
         - NP_BUILD_DEP=numpy==1.14.5
         - NP_TEST_DEP=numpy==1.14.5
     - os: linux
+      name: amd64-Linux-Py37
       env:
         - MB_PYTHON_VERSION=3.7
         - NP_BUILD_DEP=numpy==1.14.5
         - NP_TEST_DEP=numpy==1.14.5
         - CYTHON_BUILD_DEP="Cython"
     - os: linux
+      name: amd64-Linux-Py38
       env:
         - MB_PYTHON_VERSION=3.8
         - NP_BUILD_DEP=numpy==1.17.3
         - NP_TEST_DEP=numpy==1.17.3
         - CYTHON_BUILD_DEP="Cython"
     - os: linux
+      name: 32bit-amd64-Linux-Py38
       env:
         - MB_PYTHON_VERSION=3.8
         - PLAT=i686
@@ -120,6 +128,7 @@ jobs:
         - NP_TEST_DEP=numpy==1.17.3
         - CYTHON_BUILD_DEP="Cython"
     - os: linux
+      name: 32bit-amd64-Linux-Py37
       env:
         - MB_PYTHON_VERSION=3.7
         - PLAT=i686
@@ -127,12 +136,14 @@ jobs:
         - NP_TEST_DEP=numpy==1.14.5
         - CYTHON_BUILD_DEP="Cython"
     - os: osx
+      name: osx-Py36
       language: generic
       env:
         - MB_PYTHON_VERSION=3.6
         - NP_BUILD_DEP=numpy==1.14.5
         - NP_TEST_DEP=numpy==1.14.5
     - os: osx
+      name: osx-Py37
       language: generic
       env:
         - MB_PYTHON_VERSION=3.7
@@ -140,6 +151,7 @@ jobs:
         - NP_TEST_DEP=numpy==1.14.5
         - CYTHON_BUILD_DEP="Cython"
     - os: osx
+      name: osx-Py38
       language: generic
       osx_image: xcode10.1
       env:
@@ -150,6 +162,7 @@ jobs:
         - MB_PYTHON_OSX_VER=10.9
 
     - stage: Test wheel
+      name: ARM64-Linux-Py37
       arch: arm64-graviton2
       dist: focal
       virt: vm
@@ -165,6 +178,7 @@ jobs:
       install:
         - echo "This stage will test and upload the AArch64 wheel"
     - arch: arm64-graviton2
+      name: ARM64-Linux-Py36
       dist: focal
       virt: vm
       group: edge
@@ -179,6 +193,7 @@ jobs:
       install:
         - echo "This stage will test and upload the AArch64 wheel"
     - arch: arm64-graviton2
+      name: ARM64-Linux-Py38
       dist: focal
       virt: vm
       group: edge

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ environment:
       WHEELHOUSE_UPLOADER_SECRET:
         secure:
             jIyaD+VWmTlDGXThsKAkiLq8iljgYHiriq+kEUuW9tHj67R5BapLxLjbfco2nt8Y
-      BUILD_COMMIT: 01d8bfb
+      BUILD_COMMIT: c72ad0c
       DAILY_COMMIT: master
 
   matrix:

--- a/config.sh
+++ b/config.sh
@@ -63,7 +63,7 @@ function build_osx_wheel {
 function run_tests {
     # Runs tests on installed distribution from an empty directory
     # OSX tests seem to time out pretty often
-    if [ -z "$IS_OSX" ]; then
+    if [[ -z "$IS_OSX" && `uname -m` != 'aarch64' ]]; then
         local testmode="full"
     else
         local testmode="fast"
@@ -71,7 +71,11 @@ function run_tests {
     # Check bundled license file
     python ../check_installed_package.py
     # Run tests
-    python ../run_scipy_tests.py $testmode -- -n2 -rfEX
+    if [[ -z "$IS_OSX" && `uname -m` != 'aarch64' ]]; then
+        python ../run_scipy_tests.py $testmode -- -n2 -rfEX
+    else
+        python ../run_scipy_tests.py $testmode -- -n8 -rfEX
+    fi
     # Show BLAS / LAPACK used
     python -c 'import scipy; scipy.show_config()'
 }


### PR DESCRIPTION
* try adding the ARM64 wheel builds to the `v1.5.x` wheels branch--an early sniff test to see if we run into issues with provision of ARM wheels for Linux on this older release branch

* point the builds to the tip of the maintenance branch in the main repo while I'm at it to get latest build of the branch

* the only notable backport I left out from `master` was a `multibuild` submodule bump; can do that if needed but being conservative initially