### PR TITLE
DOC, MAINT: update README Travis CI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ We automate wheel building using this custom github repository that builds on
 the travis-ci OSX machines and the travis-ci Linux machines.
 
 The travis-ci interface for the builds is
-https://travis-ci.org/MacPython/scipy-wheels
+https://travis-ci.com/github/MacPython/scipy-wheels
 
 Appveyor interface at
 https://ci.appveyor.com/project/scipy/scipy-wheels


### PR DESCRIPTION
* update the `README` file to reflect our recent migration
to new Travis CI site (`.com` instead of `.org`)
for wheel builds