### PR TITLE
MAINT: turn on Windows Python 3.9

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,20 @@ environment:
       DAILY_COMMIT: master
 
   matrix:
+    - PYTHON: C:\Python39
+      PYTHON_VERSION: 3.9
+      PYTHON_ARCH: 32
+      NUMPY_BUILD_DEP: numpy==1.19.3
+      NUMPY_TEST_DEP: numpy==1.19.3
+      CYTHON_BUILD_DEP: Cython
+
+    - PYTHON: C:\Python39-x64
+      PYTHON_VERSION: 3.9
+      PYTHON_ARCH: 64
+      NUMPY_BUILD_DEP: numpy==1.19.3
+      NUMPY_TEST_DEP: numpy==1.19.3
+      CYTHON_BUILD_DEP: Cython
+
     - PYTHON: C:\Python38
       PYTHON_VERSION: 3.8
       PYTHON_ARCH: 32


### PR DESCRIPTION
* backport of gh-101 to turn on Windows Python 3.9 building/testing for the `v1.5.x` wheels branch