### PR TITLE
BLD: update commit hashes to point at tip of scipy mckib2:gcc48to52

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ env:
     global:
         - REPO_DIR=scipy
         # Also see DAILY_COMMIT below
-        - BUILD_COMMIT=ab1c0907f
+        - BUILD_COMMIT=68eb089
         - PLAT=x86_64
         - CYTHON_BUILD_DEP="Cython==0.29.18"
         - PYBIND11_BUILD_DEP="pybind11==2.4.3"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ environment:
       WHEELHOUSE_UPLOADER_SECRET:
         secure:
             jIyaD+VWmTlDGXThsKAkiLq8iljgYHiriq+kEUuW9tHj67R5BapLxLjbfco2nt8Y
-      BUILD_COMMIT: ab1c0907f
+      BUILD_COMMIT: 68eb089
       DAILY_COMMIT: master
 
   matrix:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ pr:
 - master
 
 variables:
-  BUILD_COMMIT: "ab1c0907f"
+  BUILD_COMMIT: "68eb089"
 
 jobs:
   - template: azure-posix.yml


### PR DESCRIPTION
- see https://github.com/scipy/scipy/pull/13347
- testing to see if wheels using gcc5 need extra compiler/linker arguments as in https://github.com/pypa/auditwheel/issues/125
- the scipy branch currently does not use any special compiler/linker arguments -- this is a fact-finding mission