### PR TITLE
MAINT: force azure uploads

### DIFF
--- a/azure-posix.yml
+++ b/azure-posix.yml
@@ -120,7 +120,7 @@ jobs:
 
           echo uploading wheelhouse/*.whl
 
-          anaconda -v -t $TOKEN upload -u $ANACONDA_ORG wheelhouse/*.whl
+          anaconda -v -t $TOKEN upload --force -u $ANACONDA_ORG wheelhouse/*.whl
           echo "PyPI-style index: https://pypi.anaconda.org/$ANACONDA_ORG/simple"
         displayName: Upload to anaconda.org (only if secret token is retrieved)
         condition: ne(variables['TOKEN'], '')


### PR DESCRIPTION
Fixes #112

* we already `--force` uploads on Travis
and Appveyor; otherwise, we can't upload
fixed versions of releases to staging areas
on Azure

* use Travis skip tags to avoid wasting travis
resources here

[skip travis] [skip travis-ci]