### PR TITLE
MAINT: pin anaconda-client and add pythran build dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -167,7 +167,7 @@ after_success:
           source extra_functions.sh;
           for f in wheelhouse/*.whl; do rename_wheel $f; done;
           ANACONDA_ORG="scipy-wheels-nightly";
-          pip install git+https://github.com/Anaconda-Server/anaconda-client;
+          pip install git+https://github.com/Anaconda-Platform/anaconda-client.git@ce89e4351eef;
           anaconda -t ${SCIPY_WHEELS_NIGHTLY} upload --force -u ${ANACONDA_ORG} ${TRAVIS_BUILD_DIR}/wheelhouse/*.whl;
       fi
     # for merges (push events) we use the staging area instead;
@@ -176,6 +176,6 @@ after_success:
     # multibuild-wheels-staging
     - if [ "$TRAVIS_EVENT_TYPE" == "push" ]; then
           ANACONDA_ORG="multibuild-wheels-staging";
-          pip install git+https://github.com/Anaconda-Server/anaconda-client;
+          pip install git+https://github.com/Anaconda-Platform/anaconda-client.git@ce89e4351eef;
           anaconda -t ${SCIPY_STAGING_UPLOAD_TOKEN} upload --force -u ${ANACONDA_ORG} ${TRAVIS_BUILD_DIR}/wheelhouse/*.whl;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
         - BUILD_COMMIT=master
         - PLAT=x86_64
         - CYTHON_BUILD_DEP="Cython==0.29.18"
+        - PYTHRAN_BUILD_DEP="pythran"
         - PYBIND11_BUILD_DEP="pybind11==2.4.3"
         - UNICODE_WIDTH=32
         - MANYLINUX_URL="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
@@ -140,7 +141,7 @@ before_install:
           CONTAINER=wheels;
           UPLOAD_ARGS="--no-update-index";
       fi
-    - BUILD_DEPENDS="wheel oldest-supported-numpy $CYTHON_BUILD_DEP $PYBIND11_BUILD_DEP"
+    - BUILD_DEPENDS="wheel oldest-supported-numpy $CYTHON_BUILD_DEP $PYTHRAN_BUILD_DEP $PYBIND11_BUILD_DEP"
     - TEST_DEPENDS="oldest-supported-numpy pytest pytest-xdist pytest-faulthandler pytest-env"
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -221,5 +221,5 @@ on_success:
   # multibuild-wheels-staging site
   - cd ..\scipy
   - cmd: set ANACONDA_ORG="multibuild-wheels-staging"
-  - pip install git+https://github.com/Anaconda-Server/anaconda-client
+  - pip install git+https://github.com/Anaconda-Platform/anaconda-client.git@ce89e4351eef
   - IF NOT "%SCIPY_STAGING_UPLOAD_TOKEN%" == "" anaconda -t %SCIPY_STAGING_UPLOAD_TOKEN% upload --force -u %ANACONDA_ORG% "dist\*.whl"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ environment:
       MINGW_32: C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin
       MINGW_64: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
       CYTHON_BUILD_DEP: Cython==0.29.18
+      PYTHRAN_BUILD_DEP: pythran
       NUMPY_TEST_DEP: numpy==1.16.5
       PYBIND11_BUILD_DEP: pybind11==2.4.3
       TEST_MODE: fast
@@ -125,7 +126,7 @@ install:
   - python -m pip install -U pip setuptools wheel
 
   # Install build requirements.
-  - pip install "%CYTHON_BUILD_DEP%" "%NUMPY_BUILD_DEP%" "%PYBIND11_BUILD_DEP%"
+  - pip install "%CYTHON_BUILD_DEP%" "%PYTHRAN_BUILD_DEP%" "%NUMPY_BUILD_DEP%" "%PYBIND11_BUILD_DEP%"
 
   # Replace numpy distutils with a version that can build with msvc + mingw-gfortran,
   # and writes __config__.py suitable for Python 3.8. (Requires Numpy >= 1.18.0)

--- a/azure-posix.yml
+++ b/azure-posix.yml
@@ -59,7 +59,7 @@ jobs:
           set -e
           echo building for commit "$BUILD_COMMIT"
           pip install --upgrade virtualenv wheel setuptools
-          BUILD_DEPENDS="wheel oldest-supported-numpy Cython>=0.29.18 pybind11>=2.4.3"
+          BUILD_DEPENDS="wheel oldest-supported-numpy Cython>=0.29.18 pybind11>=2.4.3 pythran"
 
           source multibuild/common_utils.sh
           source multibuild/travis_steps.sh


### PR DESCRIPTION
Fixes #115

Forward-port the fix that worked for the `v1.6.x` wheels branch `anaconda-client` upload issue. Does not affect Azure Pipelines because they use `conda` to obtain the dependency instead of `pip`.

* pin the `anaconda-client` commit hash used for
Travis and Appveyor `pip` installs to avoid a
problematic dependency addition to `requirements.txt`