### PR TITLE
Add -m32 to the 32-bit Python on Windows builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -164,6 +164,13 @@ build_script:
       $PYTHON_ARCH = $env:PYTHON_ARCH
       If ($PYTHON_ARCH -eq 32) {
           $MINGW = $env:MINGW_32
+          # 32-bit build requires careful adjustments
+          # until Microsoft has a switch we can use
+          # directly for i686 mingw
+          $env:NPY_DISTUTILS_APPEND_FLAGS = 1
+          $env:CFLAGS = "-m32"
+          $env:LDFLAGS = "-m32"
+          refreshenv
       } Else {
           $MINGW = $env:MINGW_64
       }


### PR DESCRIPTION
This change is copied from the Azure setup in the main SciPy repo. It should fix the Pythran build issue.