### PR TITLE
MAINT: boost submodule Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -176,6 +176,7 @@ build_script:
       }
       $env:Path += ";$MINGW"
       $env:NPY_NUM_BUILD_JOBS = "4"
+  - git submodule update --init
   - python setup.py bdist_wheel
   - ps: |
       # Upload artifact to Appveyor immediately after build


### PR DESCRIPTION
Fixes #120 

* try to fix absence of boost submodule in Appveyor
wheel builds; note that this is the third usage
of `git submodule update --init` in the Appveyor config
file--the previous two use cases were added years ago
by Matthew Brett and Pauli and appear to be related to
the wheels infrastructure rather than the SciPy checkout
proper (the addition here is after `cd scipy` so hopefully
it works..)

* skip Travis CI builds to save credits..

* if/when this works, the patch should likely be pushed right
into the `v1.7.x` wheels branch with Travis skipped as well

[skip travis] [skip travis ci] [skip travis-ci] [travis skip]