### PR TITLE
Change CFLAGS to CXXFLAGS for passing -m32 to Pythran

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -168,7 +168,7 @@ build_script:
           # until Microsoft has a switch we can use
           # directly for i686 mingw
           $env:NPY_DISTUTILS_APPEND_FLAGS = 1
-          $env:CFLAGS = "-m32"
+          $env:CXXFLAGS = "-m32"
           $env:LDFLAGS = "-m32"
           refreshenv
       } Else {


### PR DESCRIPTION
This changed in Pythran 0.9.10

Fixes:
```
  LINK : warning LNK4044: unrecognized option '/m32'; ignored
  Release\scipy/interpolate\_rbfinterp_pythran.cp39-win32.lib -m32" failed with exit status 1112
```