### PR TITLE
WIP, MAINT: try 3.10rc wheels

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,10 @@ jobs:
       name: linux
       vmImage: ubuntu-18.04
       matrix:
+        amd64-linux-py310:
+          AZURE_PYTHON_VERSION: "3.9"
+          MB_PYTHON_VERSION: "3.10"
+          DOCKER_TEST_IMAGE: "multibuild/focal_{PLAT}"
         amd64-linux-py39:
           MB_PYTHON_VERSION: "3.9"
         32bit-amd64-linux-py39:

--- a/azure-posix.yml
+++ b/azure-posix.yml
@@ -59,7 +59,7 @@ jobs:
           set -e
           echo building for commit "$BUILD_COMMIT"
           pip install --upgrade virtualenv wheel setuptools
-          BUILD_DEPENDS="wheel oldest-supported-numpy Cython>=0.29.18 pybind11>=2.4.3 pythran"
+          BUILD_DEPENDS="wheel oldest-supported-numpy Cython>=0.29.24 pybind11>=2.4.3 pythran"
 
           source multibuild/common_utils.sh
           source multibuild/travis_steps.sh


### PR DESCRIPTION
* mimic the approach used by NumPy wheels
in: https://github.com/MacPython/numpy-wheels/pull/129

* what could go wrong.. (skip Travis for now)

I'm guessing it is not going to be as easy as just copying what @mattip and @charris did but isn't going to stop me from trying :) Some of our SciPy wheels infra/base images normally used are a bit older perhaps too?

I think even if we do succeed I'd be hesitant to actually put the rc wheel on PyPI vs. just making it available on the anaconda testbed.