### PR TITLE
WIP, MAINT: backport 3.10 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/scipy/scipy.git
 [submodule "multibuild"]
 	path = multibuild
-	url = https://github.com/matthew-brett/multibuild.git
+	url = https://github.com/multi-build/multibuild.git
 [submodule "gfortran-install"]
 	path = gfortran-install
 	url = https://github.com/MacPython/gfortran-install.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     global:
         - REPO_DIR=scipy
         # Also see DAILY_COMMIT below
-        - BUILD_COMMIT=1bbc2b4
+        - BUILD_COMMIT=5f587c6
         - PLAT=x86_64
         - CYTHON_BUILD_DEP="Cython==0.29.24"
         - PYTHRAN_BUILD_DEP="pythran"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ env:
     global:
         - REPO_DIR=scipy
         # Also see DAILY_COMMIT below
-        - BUILD_COMMIT=47bb6feb
+        - BUILD_COMMIT=1bbc2b4
         - PLAT=x86_64
-        - CYTHON_BUILD_DEP="Cython==0.29.18"
+        - CYTHON_BUILD_DEP="Cython==0.29.24"
         - PYTHRAN_BUILD_DEP="pythran"
-        - PYBIND11_BUILD_DEP="pybind11==2.4.3"
+        - PYBIND11_BUILD_DEP="pybind11>=2.4.3"
         - UNICODE_WIDTH=32
         - MANYLINUX_URL="https://5cf40426d9f06eb7461d-6fe47d9331aba7cd62fc36c7196769e4.ssl.cf2.rackcdn.com"
         - WHEELHOUSE_UPLOADER_USERNAME=travis-worker
@@ -44,6 +44,7 @@ jobs:
         - PLAT=aarch64
         - CYTHON_BUILD_DEP="Cython"
         - DOCKER_IMAGE=quay.io/pypa/manylinux2014_${PLAT}
+        - MB_ML_VER=2014
       script:
         - echo "This stage will just build AArch64 wheel"
       workspaces:
@@ -64,6 +65,7 @@ jobs:
         - PLAT=aarch64
         - CYTHON_BUILD_DEP="Cython"
         - DOCKER_IMAGE=quay.io/pypa/manylinux2014_${PLAT}
+        - MB_ML_VER=2014
       script:
         - echo "This stage will just build AArch64 wheel"
       workspaces:
@@ -84,6 +86,7 @@ jobs:
         - PLAT=aarch64
         - CYTHON_BUILD_DEP="Cython"
         - DOCKER_IMAGE=quay.io/pypa/manylinux2014_${PLAT}
+        - MB_ML_VER=2014
       script:
         - echo "This stage will just build AArch64 wheel"
       workspaces:
@@ -93,20 +96,41 @@ jobs:
             - wheelhouse
       after_success:
         - echo "This stage will not upload aarch64 wheel"
-
-    - stage: Test wheel
-      name: ARM64-Linux-Py37
+    - os: linux
+      name: ARM64-Linux-Py310
       arch: arm64-graviton2
       dist: focal
       virt: vm
       group: edge
       env:
-        - MB_PYTHON_VERSION=3.7
+        - MB_PYTHON_VERSION=3.10
         - PLAT=aarch64
         - CYTHON_BUILD_DEP="Cython"
-        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+        - DOCKER_IMAGE=quay.io/pypa/manylinux2014_${PLAT}
+        - MB_ML_VER=2014
+      script:
+        - echo "This stage will just build AArch64 wheel"
       workspaces:
-        use: ws1
+        create:
+          name: ws5
+          paths:
+            - wheelhouse
+      after_success:
+        - echo "This stage will not upload aarch64 wheel"
+    - stage: Test wheel
+      arch: arm64-graviton2
+      name: ARM64-Linux-Py310
+      dist: focal
+      virt: vm
+      group: edge
+      env:
+        - MB_PYTHON_VERSION=3.10
+        - PLAT=aarch64
+        - CYTHON_BUILD_DEP="Cython"
+        - DOCKER_TEST_IMAGE=multibuild/focal_{PLAT}
+        - MB_ML_VER=2014
+      workspaces:
+        use: ws5
       install:
         - echo "This stage will test and upload the AArch64 wheel"
     - arch: arm64-graviton2
@@ -118,7 +142,8 @@ jobs:
         - MB_PYTHON_VERSION=3.9
         - PLAT=aarch64
         - CYTHON_BUILD_DEP="Cython"
-        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+        - DOCKER_TEST_IMAGE=multibuild/focal_{PLAT}
+        - MB_ML_VER=2014
       workspaces:
         use: ws4
       install:
@@ -132,9 +157,25 @@ jobs:
         - MB_PYTHON_VERSION=3.8
         - PLAT=aarch64
         - CYTHON_BUILD_DEP="Cython"
-        - DOCKER_TEST_IMAGE=multibuild/xenial_arm64v8
+        - DOCKER_TEST_IMAGE=multibuild/focal_{PLAT}
+        - MB_ML_VER=2014
       workspaces:
         use: ws3
+      install:
+        - echo "This stage will test and upload the AArch64 wheel"
+    - arch: arm64-graviton2
+      name: ARM64-Linux-Py37
+      dist: focal
+      virt: vm
+      group: edge
+      env:
+        - MB_PYTHON_VERSION=3.7
+        - PLAT=aarch64
+        - CYTHON_BUILD_DEP="Cython"
+        - DOCKER_TEST_IMAGE=multibuild/focal_{PLAT}
+        - MB_ML_VER=2014
+      workspaces:
+        use: ws1
       install:
         - echo "This stage will test and upload the AArch64 wheel"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ environment:
       WHEELHOUSE_UPLOADER_SECRET:
         secure:
             jIyaD+VWmTlDGXThsKAkiLq8iljgYHiriq+kEUuW9tHj67R5BapLxLjbfco2nt8Y
-      BUILD_COMMIT: 1bbc2b4
+      BUILD_COMMIT: 5f587c6
       DAILY_COMMIT: master
 
   matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,17 +5,19 @@ clone_depth: 50
 # No reason for us to restrict the number concurrent jobs
 max_jobs: 100
 
+image: Visual Studio 2017
+
 cache:
   - '%LOCALAPPDATA%\pip\Cache'
 
 environment:
   global:
-      MINGW_32: C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin
-      MINGW_64: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin
-      CYTHON_BUILD_DEP: Cython==0.29.18
+      MINGW_32: C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw32\bin
+      MINGW_64: C:\mingw-w64\x86_64-7.3.0-posix-seh-rt_v5-rev0\mingw64\bin
+      CYTHON_BUILD_DEP: Cython==0.29.24
       PYTHRAN_BUILD_DEP: pythran
       NUMPY_TEST_DEP: numpy==1.16.5
-      PYBIND11_BUILD_DEP: pybind11==2.4.3
+      PYBIND11_BUILD_DEP: pybind11==2.7.0
       TEST_MODE: fast
       APPVEYOR_SAVE_CACHE_ON_ERROR: true
       APPVEYOR_SKIP_FINALIZE_ON_EXIT: true
@@ -23,10 +25,17 @@ environment:
       WHEELHOUSE_UPLOADER_SECRET:
         secure:
             jIyaD+VWmTlDGXThsKAkiLq8iljgYHiriq+kEUuW9tHj67R5BapLxLjbfco2nt8Y
-      BUILD_COMMIT: 47bb6feb
+      BUILD_COMMIT: 1bbc2b4
       DAILY_COMMIT: master
 
   matrix:
+    - PYTHON: C:\Python310-x64
+      PYTHON_VERSION: 3.10.0
+      PYTHON_ARCH: 64
+      NUMPY_BUILD_DEP: oldest-supported-numpy
+      NUMPY_TEST_DEP: oldest-supported-numpy
+      CYTHON_BUILD_DEP: Cython
+
     - PYTHON: C:\Python39
       PYTHON_VERSION: 3.9
       PYTHON_ARCH: 32
@@ -86,8 +95,11 @@ install:
   - cmd: echo "Filesystem root:"
   - dir C:\
 
-  - echo "Installed SDKs:"
-  - dir "C:/Program Files/Microsoft SDKs/Windows"
+  - echo "List Program Files:"
+  - dir "C:\Program Files (x86)\"
+
+  # install a newer mingw for i686 as the appveyor images don't have gcc 7+ for i686
+  - if [%PYTHON_ARCH%]==[32] choco install -y mingw --forcex86 --force --version=7.3.0
 
   - git submodule update --init
 
@@ -126,7 +138,7 @@ install:
   - python -m pip install -U pip setuptools wheel
 
   # Install build requirements.
-  - pip install "%CYTHON_BUILD_DEP%" "%PYTHRAN_BUILD_DEP%" "%NUMPY_BUILD_DEP%" "%PYBIND11_BUILD_DEP%"
+  - python -m pip install "%CYTHON_BUILD_DEP%" "%PYTHRAN_BUILD_DEP%" "%NUMPY_BUILD_DEP%" "%PYBIND11_BUILD_DEP%"
 
   # Replace numpy distutils with a version that can build with msvc + mingw-gfortran,
   # and writes __config__.py suitable for Python 3.8. (Requires Numpy >= 1.18.0)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ pr:
 - master
 
 variables:
-  BUILD_COMMIT: "47bb6feb"
+  BUILD_COMMIT: "1bbc2b4"
 
 jobs:
   - template: azure-posix.yml
@@ -19,13 +19,24 @@ jobs:
       name: linux
       vmImage: ubuntu-18.04
       matrix:
+        amd64-linux-py3.10:
+          AZURE_PYTHON_VERSION: "3.9"
+          MB_PYTHON_VERSION: "3.10"
+          MB_ML_VER: "2014"
+          DOCKER_TEST_IMAGE: "multibuild/focal_{PLAT}"
+
         amd64-linux-py39:
           MB_PYTHON_VERSION: "3.9"
+          MB_ML_VER: "2014"
         32bit-amd64-linux-py39:
           MB_PYTHON_VERSION: "3.9"
+          MB_ML_VER: "2010"
           PLAT: "i686"
+          DOCKER_TEST_IMAGE: "multibuild/xenial_{PLAT}"
+
         amd64-linux-py38:
           MB_PYTHON_VERSION: "3.8"
+          MB_ML_VER: "2014"
         32bit-amd64-linux-py38:
           MB_PYTHON_VERSION: "3.8"
           PLAT: "i686"
@@ -38,13 +49,25 @@ jobs:
   - template: azure-posix.yml
     parameters:
       name: macOS
-      vmImage: macOS-10.14
+      vmImage: macOS-10.15
       matrix:
         osx-Py37:
           MB_PYTHON_VERSION: "3.7"
         osx-Py38:
           MB_PYTHON_VERSION: "3.8"
           MB_PYTHON_OSX_VER: "10.9"
+        osx-Py38-universal2:
+          MB_PYTHON_VERSION: "3.8"
+          MB_PYTHON_OSX_VER: "10.9"
+          PLAT: universal2
         osx-Py39:
           MB_PYTHON_VERSION: "3.9"
           MB_PYTHON_OSX_VER: "10.9"
+        osx-Py39-universal2:
+          MB_PYTHON_VERSION: "3.9"
+          MB_PYTHON_OSX_VER: "10.9"
+          PLAT: universal2
+        osx-Py310-universal2:
+          MB_PYTHON_VERSION: "3.10"
+          MB_PYTHON_OSX_VER: "10.9"
+          PLAT: universal2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,7 @@ schedules:
 
 pr:
 - master
+- v1.7.x
 
 variables:
   BUILD_COMMIT: "1bbc2b4"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,11 +41,14 @@ jobs:
         32bit-amd64-linux-py38:
           MB_PYTHON_VERSION: "3.8"
           PLAT: "i686"
+          MB_ML_VER: "2010"
         amd64-linux-py37:
           MB_PYTHON_VERSION: "3.7"
+          MB_ML_VER: "2010"
         32bit-amd64-linux-py37:
           MB_PYTHON_VERSION: "3.7"
           PLAT: "i686"
+          MB_ML_VER: "2010"
 
   - template: azure-posix.yml
     parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,7 +63,7 @@ jobs:
         osx-Py39:
           MB_PYTHON_VERSION: "3.9"
           MB_PYTHON_OSX_VER: "10.9"
-        osx-Py310-universal2:
+        osx-Py310:
           MB_PYTHON_VERSION: "3.10"
           MB_PYTHON_OSX_VER: "10.9"
-          PLAT: universal2
+          PLAT: x86_64

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ pr:
 - v1.7.x
 
 variables:
-  BUILD_COMMIT: "1bbc2b4"
+  BUILD_COMMIT: "5f587c6"
 
 jobs:
   - template: azure-posix.yml
@@ -60,17 +60,9 @@ jobs:
         osx-Py38:
           MB_PYTHON_VERSION: "3.8"
           MB_PYTHON_OSX_VER: "10.9"
-        osx-Py38-universal2:
-          MB_PYTHON_VERSION: "3.8"
-          MB_PYTHON_OSX_VER: "10.9"
-          PLAT: universal2
         osx-Py39:
           MB_PYTHON_VERSION: "3.9"
           MB_PYTHON_OSX_VER: "10.9"
-        osx-Py39-universal2:
-          MB_PYTHON_VERSION: "3.9"
-          MB_PYTHON_OSX_VER: "10.9"
-          PLAT: universal2
         osx-Py310-universal2:
           MB_PYTHON_VERSION: "3.10"
           MB_PYTHON_OSX_VER: "10.9"

--- a/azure-posix.yml
+++ b/azure-posix.yml
@@ -5,6 +5,7 @@ parameters:
 
 jobs:
   - job: ${{ parameters.name }}
+    timeoutInMinutes: 90
     pool:
       vmImage: ${{ parameters.vmImage }}
     variables:
@@ -12,6 +13,7 @@ jobs:
       PLAT: "x86_64"
       NIGHTLY_BUILD_COMMIT: "master"
       DAILY_COMMIT: "master"
+      MB_ML_VER: "1"
     strategy:
       matrix:
         ${{ insert }}: ${{ parameters.matrix }}
@@ -56,10 +58,11 @@ jobs:
         displayName: Define build env variables
 
       - bash: |
-          set -e
+          set -ex
           echo building for commit "$BUILD_COMMIT"
+
           pip install --upgrade virtualenv wheel setuptools
-          BUILD_DEPENDS="wheel oldest-supported-numpy Cython>=0.29.18 pybind11>=2.4.3 pythran"
+          BUILD_DEPENDS="wheel oldest-supported-numpy Cython>=0.29.24 pybind11>=2.4.3 pythran"
 
           source multibuild/common_utils.sh
           source multibuild/travis_steps.sh

--- a/run_scipy_tests.py
+++ b/run_scipy_tests.py
@@ -6,6 +6,7 @@ Run scipy tests allowing for pytest and nosetests
 
 import sys
 import argparse
+import multiprocessing
 
 
 def main():


### PR DESCRIPTION
* try to backport some of the pertinent
changes for Python 3.10 support to the wheels
repo `v1.7.x` branch, which needs to continue
supporting Python 3.7

* perhaps we can do away with some of the manylinux
bumps--not sure on those--things are going to change
a fair bit anyway with a huge bump in OpenBLAS version
as well; perhaps the bumps could be confined to just 3.10
using newer manylinux??

* point `BUILD_COMMIT` at the tip of the target maintenance
branch to get more useful feedback on where we stand
for the 3.10 wheel builds