### PR TITLE
MAINT: add thin wheels, some fixes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,6 +55,10 @@ jobs:
           MB_PYTHON_VERSION: "3.8"
           MB_PYTHON_OSX_VER: "10.9"
           PLAT: universal2
+        osx-Py38_arm64:
+          MB_PYTHON_VERSION: "3.8"
+          MB_PYTHON_OSX_VER: "12.0"
+          PLAT: arm64
         osx-Py39:
           MB_PYTHON_VERSION: "3.9"
           MB_PYTHON_OSX_VER: "10.9"
@@ -62,7 +66,19 @@ jobs:
           MB_PYTHON_VERSION: "3.9"
           MB_PYTHON_OSX_VER: "10.9"
           PLAT: universal2
+        osx-Py39_arm64:
+          MB_PYTHON_VERSION: "3.9"
+          MB_PYTHON_OSX_VER: "12.0"
+          PLAT: arm64
+        osx-Py310:
+          MB_PYTHON_VERSION: "3.10"
+          MB_PYTHON_OSX_VER: "10.9"
+          PLAT: x86_64
         osx-Py310-universal2:
           MB_PYTHON_VERSION: "3.10"
           MB_PYTHON_OSX_VER: "10.9"
           PLAT: universal2
+        osx-Py310_arm64:
+          MB_PYTHON_VERSION: "3.10"
+          MB_PYTHON_OSX_VER: "12.0"
+          PLAT: arm64

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ jobs:
           PLAT: universal2
         osx-Py38_arm64:
           MB_PYTHON_VERSION: "3.8"
-          MB_PYTHON_OSX_VER: "12.0"
+          MB_PYTHON_OSX_VER: "11.0"
           PLAT: arm64
         osx-Py39:
           MB_PYTHON_VERSION: "3.9"
@@ -68,7 +68,7 @@ jobs:
           PLAT: universal2
         osx-Py39_arm64:
           MB_PYTHON_VERSION: "3.9"
-          MB_PYTHON_OSX_VER: "12.0"
+          MB_PYTHON_OSX_VER: "11.0"
           PLAT: arm64
         osx-Py310:
           MB_PYTHON_VERSION: "3.10"
@@ -80,5 +80,5 @@ jobs:
           PLAT: universal2
         osx-Py310_arm64:
           MB_PYTHON_VERSION: "3.10"
-          MB_PYTHON_OSX_VER: "12.0"
+          MB_PYTHON_OSX_VER: "11.0"
           PLAT: arm64

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ jobs:
           PLAT: universal2
         osx-Py38_arm64:
           MB_PYTHON_VERSION: "3.8"
-          MB_PYTHON_OSX_VER: "11.0"
+          MB_PYTHON_OSX_VER: "10.9"
           PLAT: arm64
         osx-Py39:
           MB_PYTHON_VERSION: "3.9"
@@ -68,7 +68,7 @@ jobs:
           PLAT: universal2
         osx-Py39_arm64:
           MB_PYTHON_VERSION: "3.9"
-          MB_PYTHON_OSX_VER: "11.0"
+          MB_PYTHON_OSX_VER: "10.9"
           PLAT: arm64
         osx-Py310:
           MB_PYTHON_VERSION: "3.10"

--- a/azure-posix.yml
+++ b/azure-posix.yml
@@ -80,6 +80,7 @@ jobs:
           source multibuild/travis_steps.sh
           install_run $PLAT
         displayName: Install wheel and test
+        condition: ne(variables['PLAT'], 'arm64')
 
       - bash: |
           echo "##vso[task.prependpath]$CONDA/bin"

--- a/run_scipy_tests.py
+++ b/run_scipy_tests.py
@@ -6,6 +6,7 @@ Run scipy tests allowing for pytest and nosetests
 
 import sys
 import argparse
+import multiprocessing
 
 
 def main():


### PR DESCRIPTION
* forward-port multiprocessing addition to `run_scipy_tests.py`, which
was helpful in preventing sporadic Appveyor/Windows test failures on the
`v1.7.x` branch

* forward-port Python `3.10` x86_64 thin wheel support

* add Python 3.8 to 3.10 MacOS arm64 thin wheel builds for
MacOS 12; I'll be fairly surprised if the issues for Python < 3.10
download with this super-new OS version observed in the backport PR
are not observed on `master` (need multibuild change or don't actually
need to bump the version that high to restrict to MacOS 12 only
usage of the wheel?)