### PR TITLE
BUG: now actually include `_distributor_init.py` in macOS arm64 wheel

### DIFF
--- a/patch_code.sh
+++ b/patch_code.sh
@@ -13,4 +13,5 @@ if [ -z "$IS_OSX" ]; then
     cat LICENSE_linux.txt >> $repo_dir/LICENSE.txt
 else
     cat LICENSE_osx.txt >> $repo_dir/LICENSE.txt
+    cp _distributor_init.py scipy/_distributor_init.py
 fi


### PR DESCRIPTION
This is a follow-up to gh-143