### PR TITLE
WIP, MAINT: MacOS wheels 12.0 target

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/scipy/scipy.git
 [submodule "multibuild"]
 	path = multibuild
-	url = https://github.com/multi-build/multibuild.git
+	url = https://github.com/tylerjereddy/multibuild.git
 [submodule "gfortran-install"]
 	path = gfortran-install
 	url = https://github.com/MacPython/gfortran-install.git

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,10 +55,12 @@ jobs:
           MB_PYTHON_VERSION: "3.8"
           MB_PYTHON_OSX_VER: "10.9"
           PLAT: universal2
+          MACOSX_DEPLOYMENT_TARGET: "12.0"
         osx-Py38_arm64:
           MB_PYTHON_VERSION: "3.8"
           MB_PYTHON_OSX_VER: "10.9"
           PLAT: arm64
+          MACOSX_DEPLOYMENT_TARGET: "12.0"
         osx-Py39:
           MB_PYTHON_VERSION: "3.9"
           MB_PYTHON_OSX_VER: "10.9"
@@ -66,10 +68,12 @@ jobs:
           MB_PYTHON_VERSION: "3.9"
           MB_PYTHON_OSX_VER: "10.9"
           PLAT: universal2
+          MACOSX_DEPLOYMENT_TARGET: "12.0"
         osx-Py39_arm64:
           MB_PYTHON_VERSION: "3.9"
           MB_PYTHON_OSX_VER: "10.9"
           PLAT: arm64
+          MACOSX_DEPLOYMENT_TARGET: "12.0"
         osx-Py310:
           MB_PYTHON_VERSION: "3.10"
           MB_PYTHON_OSX_VER: "10.9"
@@ -78,7 +82,9 @@ jobs:
           MB_PYTHON_VERSION: "3.10"
           MB_PYTHON_OSX_VER: "10.9"
           PLAT: universal2
+          MACOSX_DEPLOYMENT_TARGET: "12.0"
         osx-Py310_arm64:
           MB_PYTHON_VERSION: "3.10"
           MB_PYTHON_OSX_VER: "11.0"
           PLAT: arm64
+          MACOSX_DEPLOYMENT_TARGET: "12.0"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,7 @@ pr:
 
 variables:
   BUILD_COMMIT: "master"
+  MACOSX_DEPLOYMENT_TARGET: "10.9"
 
 jobs:
   - template: azure-posix.yml

--- a/azure-posix.yml
+++ b/azure-posix.yml
@@ -45,7 +45,6 @@ jobs:
           # Platform variables used in multibuild scripts
           if [ `uname` == 'Darwin' ]; then
             echo "##vso[task.setvariable variable=TRAVIS_OS_NAME]osx"
-            echo "##vso[task.setvariable variable=MACOSX_DEPLOYMENT_TARGET]10.9"
           else
             echo "##vso[task.setvariable variable=TRAVIS_OS_NAME]linux"
           fi

--- a/azure-posix.yml
+++ b/azure-posix.yml
@@ -82,11 +82,6 @@ jobs:
         displayName: Install wheel and test
         condition: ne(variables['PLAT'], 'arm64')
 
-      - bash: |
-          set -xe
-          for file in `find ./wheelhouse -type f -name '*11_0_arm64*.whl'`; do mv -v "$file" "${file/11_0_arm64/12_0_arm64}"; done
-        displayName: "Rename MacOS arm64 wheels for version 12.0 minimum"
-        condition: eq(variables['PLAT'], 'arm64')
 
       - bash: |
           set -xe


### PR DESCRIPTION
Fixes #148

* `universal2` wheels should now target MacOS 12.0+
using the approached described upstream:
https://github.com/multi-build/multibuild/issues/444#issuecomment-977573836

* fix the renaming of MacOS arm64 thin wheels to use
the same approach instead of my previous manual bash
commands

* note that, confusingly, `MACOSX_DEPLOYMENT_TARGET` is
also used in `env_vars.sh` and in `azure-posix.yml`, so
we should double check the CI logs before merging to make
sure that `pip` named the wheels correctly/we get the desired
overrides for the cases touched here