### PR TITLE
MAINT, CI: check _distributor_init.py contents

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -198,6 +198,8 @@ test_script:
   - python ..\run_scipy_tests.py %TEST_MODE% -- -n6 --junitxml=%cd%\junit-results.xml -rfEX
 
 after_test:
+  - ls ..\scipy\dist
+  - python verify_init.py ..\scipy\dist
   # Upload test results to Appveyor
   - ps: |
       If (Test-Path .\junit-results.xml) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -198,8 +198,10 @@ test_script:
   - python ..\run_scipy_tests.py %TEST_MODE% -- -n6 --junitxml=%cd%\junit-results.xml -rfEX
 
 after_test:
-  - ls ..\scipy\dist
-  - python verify_init.py ..\scipy\dist
+  - cd ..
+  - ls scipy\dist
+  - python verify_init.py scipy\dist
+  - cd tmp_test
   # Upload test results to Appveyor
   - ps: |
       If (Test-Path .\junit-results.xml) {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -143,7 +143,7 @@ build_script:
       $cwd = Get-Location
       ls $cwd
       rm -Force $cwd/scipy/scipy/_distributor_init.py
-      mv $cwd/_distributor_init.py $cwd/scipy/scipy/
+      cp $cwd/_distributor_init.py $cwd/scipy/scipy/
       cd scipy
   # Append license text relevant for the built wheel
   - type ..\LICENSE_win32.txt >> LICENSE.txt

--- a/azure-posix.yml
+++ b/azure-posix.yml
@@ -89,6 +89,11 @@ jobs:
         condition: eq(variables['PLAT'], 'arm64')
 
       - bash: |
+          set -xe
+          python verify_init.py ./wheelhouse
+        displayName: "Check for appropriate contents of _distributor_init.py"
+
+      - bash: |
           echo "##vso[task.prependpath]$CONDA/bin"
           sudo chown -R $USER $CONDA
         displayName: Add conda to PATH

--- a/patch_code.sh
+++ b/patch_code.sh
@@ -13,5 +13,5 @@ if [ -z "$IS_OSX" ]; then
     cat LICENSE_linux.txt >> $repo_dir/LICENSE.txt
 else
     cat LICENSE_osx.txt >> $repo_dir/LICENSE.txt
-    cp _distributor_init.py scipy/_distributor_init.py
+    cp _distributor_init.py scipy/scipy/_distributor_init.py
 fi

--- a/verify_init.py
+++ b/verify_init.py
@@ -1,0 +1,40 @@
+"""
+Small CLI script that accepts the path to a directory containing one
+or more wheel files.
+
+Check that a wheel appropriately includes/excludes
+_distributor_init.py with the contents of that same
+file in the wheels repo.
+"""
+
+import sys
+import pathlib
+from zipfile import ZipFile
+
+
+def check_for_dist_init(input_dir):
+    p = pathlib.Path(input_dir)
+    wheel_files = p.glob('**/*.whl')
+    for wheel_file in wheel_files:
+        with ZipFile(wheel_file) as zipf:
+            file_names = zipf.namelist()
+            dist_init_found = 0
+            for file_name in file_names:
+                if "_distributor_init.py" in file_name:
+                    dist_init_found += 1
+                    with zipf.open(file_name) as actual_file:
+                        with open("_distributor_init.py", 'rb') as reference_file:
+                            # currently just MacOS and Windows should have _distributor_init.py
+                            # copied in from wheels repo; Linux should just have a generic
+                            # version of the file
+                            if "-macosx" in str(wheel_file) or "-win" in str(wheel_file):
+                                actual_content = actual_file.read()
+                                expected_content = reference_file.read()
+                                if not actual_content == expected_content:
+                                    raise ValueError(f"Contents of _distributor_init.py incorrect for {wheel_file}")
+            if not dist_init_found:
+                raise FileNotFoundError(f"_distributor_init.py missing from {wheel_file}")
+
+if __name__ == "__main__":
+    input_dir = sys.argv[1]
+    check_for_dist_init(input_dir=input_dir)


### PR DESCRIPTION
* following on from continued problems reported here:
https://github.com/scipy/scipy/issues/15050

* draft in code to check that MacOS wheels get
the same `_distributor_init.py` as the one present
in the wheels repo, rather than the generic nearly-empty
copy actually present in the `1.7.3` release

* we've had two pull requests about this and it slipped through into
a release despite 3 sets of eyes so need to be careful here;
I'd like to see the test script added here failing for MacOS in CI
like it does locally, before attempting a fix

* this is likely still WIP, since relative paths/directories
can be confusing to predict in the wheels/multibuild control
flow, which also flushes in and out of containers I think, etc.
(this probably contributed to the original problem)

* the script did seem to work in a quick local check though, complaining
about our new MacOS file inclusion, but happy with the long-standing
windows wheel inclusion for dirs containing wheels for each OS type:

`python verify_init.py /Users/treddy/rough_work/scipy/release_173/release/installers/windows`
`python verify_init.py /Users/treddy/rough_work/scipy/release_173/release/installers/linux`
`python verify_init.py /Users/treddy/rough_work/scipy/release_173/release/installers/mac`

```
Traceback (most recent call last):
  File "verify_init.py", line 40, in <module>
    check_for_dist_init(input_dir=input_dir)
  File "verify_init.py", line 34, in check_for_dist_init
    raise ValueError(f"Contents of _distributor_init.py incorrect for
{wheel_file}")
ValueError: Contents of _distributor_init.py incorrect for
/Users/treddy/rough_work/scipy/release_173/release/installers/mac/scipy-1.7.3-cp39-cp39-macosx_10_9_x86_64.whl
```


* we could go a step farther here and error out on Linux if the contents of `_distributor_init.py` *did* match the copy in the wheels repo, since they should not for that platform, though my primary focus is to be strict on the platforms that *do* need the adjustments (MacOS/Windows)