### PR TITLE
WIP, MAINT: rename universal2 manually

### DIFF
--- a/azure-posix.yml
+++ b/azure-posix.yml
@@ -90,6 +90,12 @@ jobs:
 
       - bash: |
           set -xe
+          for file in `find ./wheelhouse -type f -name '*10_9_universal2.whl'`; do mv -v "$file" "${file/10_9_universal2/12_0_universal2}"; done
+        displayName: "Rename MacOS universal2 wheels for version 12.0 minimum"
+        condition: eq(variables['PLAT'], 'universal2')
+
+      - bash: |
+          set -xe
           python verify_init.py ./wheelhouse
         displayName: "Check for appropriate contents of _distributor_init.py"
 


### PR DESCRIPTION
Fixes #148 temporarily/hopefully (thinking of getting 1.8.0 rc process started soon..)

* until an upstream multibuild solution is ready,
"manually" rename `universal2` wheels to require
MacOS version `12.0` minimum in a manner similar
to what we are doing for the thin arm64 mac wheels

* based on the analysis of universal2 wheel names in logs:
https://github.com/MacPython/scipy-wheels/pull/150#issuecomment-989948869
and recent nightly uploads:
https://anaconda.org/scipy-wheels-nightly/scipy/files#
look like we want to move from `10_9` to `12_0` universal2
file names

* we should definitely check the logs to make sure this works,
probably by looking at what filename gets targeted by the pip
install command in the `Install wheel and test` stage
for `universal2` CI runs (the `mv` command is verbose and
should also print out the renamed file)