### PR TITLE
MAINT: prevent universal2 thin upload

### DIFF
--- a/azure-posix.yml
+++ b/azure-posix.yml
@@ -94,6 +94,16 @@ jobs:
         displayName: "Rename MacOS universal2 wheels for version 12.0 minimum"
         condition: eq(variables['PLAT'], 'universal2')
 
+      # universal2 CI jobs apparently build arm64 thin wheels
+      # as well, which have the 11_0 names we do not want to
+      # upload (see: gh-155)
+      - bash: |
+          set -xe
+          rm -v ./wheelhouse/*arm64.whl
+          ls -tlrh ./wheelhouse
+        displayName: "Prevent universal2 jobs from uploading their thin wheels"
+        condition: eq(variables['PLAT'], 'universal2')
+
       - bash: |
           set -xe
           python verify_init.py ./wheelhouse


### PR DESCRIPTION
Fixes #155 (check logs to verify though)

* it turns out that the `universal2` jobs in CI
include generation of the thin arm64 wheel artifacts,
which then get uploaded with the undesired `11_0` names,
as per this log for `1.8.0rc1`:
https://dev.azure.com/numpy/27346c6a-2774-4eac-bf85-e068127c0ccc/_apis/build/builds/21654/logs/200

* since the logs tend to disappear for Azure, it says:
```
uploading wheelhouse/scipy-1.8.0rc1-cp39-cp39-macosx_11_0_arm64.whl wheelhouse/scipy-1.8.0rc1-cp39-cp39-macosx_12_0_universal2.whl
```

* the solution I've opted for here is to do a verbose deletion
of the `*arm64.whl` file in `universal2` workflows only, followed
by a listing of files in `wheelhouse` path to increase confidence
when examining logs, etc.

* note that since we can't really test the thin arm64 wheels in
CI anyway, another viable option would be to rename the thin wheels
in the universal2 jobs to use `12_0`, upload both of those wheels,
and delete the individual thin arm64 wheel build CI jobs; for now,
I've opted for the solution that is more convenient for me--we may
be able to save electricity the other way, but we are also perhaps
interested in removing the universal2 builds some day, which might
be more work if we purge out the isolated thin arm64 builds now..

cc @rgommers @isuruf 