### PR TITLE
MAINT: disable test uploads

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -212,14 +212,14 @@ after_test:
   - python verify_init.py scipy\dist
   - cd tmp_test
   # Upload test results to Appveyor
-  - ps: |
-      If (Test-Path .\junit-results.xml) {
-        (new-object net.webclient).UploadFile(
-          "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)",
-          (Resolve-Path .\junit-results.xml)
-        )
-      }
-      $LastExitCode = 0
+  #- ps: |
+  #   If (Test-Path .\junit-results.xml) {
+  #     (new-object net.webclient).UploadFile(
+  #       "https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)",
+  #       (Resolve-Path .\junit-results.xml)
+  #     )
+  #   }
+  #   $LastExitCode = 0
 
   # Remove old or huge cache files to hopefully not exceed the 1GB cache limit.
   #


### PR DESCRIPTION
Related to gh-164

* uploading the XML test suite result data to
the Appveyor service has failed for me six
times in a row now, and I need to get this release
out, so this feature branch attempts to disable the
part of the control flow that uploads the XML
data

* the tests themselves should still run, we just
won't see the pretty metadata in the Appveyor
UI for now on the wheels release branch

* `test_quad_vec_pool` may still fail stochastically
b/c of multiprocessing permissions issues on Windows,
but this I can at least restart the failing jobs for,
while the XML upload has a 0 % success rate on 6 consecutive
tries for all matrix entries