### PR TITLE
Stop cron jobs running on master

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,12 +1,3 @@
-schedules:
-- cron: "27 3 * * 0"
-  # 3:27am UTC every Sunday
-  displayName: Weekly build
-  branches:
-    include:
-    - master
-  always: true
-
 pr:
 - master
 


### PR DESCRIPTION
We're switching over to cibuildwheel in the main SciPy repo,
so no need for these jobs anymore. The nightlies will be uploaded
from a weekly scheduled run of `cibuildwheel`.

Appveyor doesn't run cron jobs, and TravisCI cron jobs are not defined
in the yml file but in its web UI, so this is all there is to do here.

[ci skip]